### PR TITLE
Collections converters

### DIFF
--- a/macros/src/main/scala/com/avast/cactus/CactusException.scala
+++ b/macros/src/main/scala/com/avast/cactus/CactusException.scala
@@ -1,3 +1,0 @@
-package com.avast.cactus
-
-case class CactusException(failure: CactusFailure) extends RuntimeException(failure.message)

--- a/macros/src/main/scala/com/avast/cactus/CactusMacros.scala
+++ b/macros/src/main/scala/com/avast/cactus/CactusMacros.scala
@@ -172,7 +172,7 @@ object CactusMacros {
           })
 
           // collections don't have the "has" method, test if empty instead
-          q" if (!$getter.isEmpty) Good(CactusMacros.CollAToCollB($getter.asScala.$toFinalCollection)) else Bad(One(MissingFieldFailure($nameInGpb))) "
+          q" Good(CactusMacros.CollAToCollB($getter.asScala.$toFinalCollection)) "
 
         case t => // plain type
 

--- a/macros/src/main/scala/com/avast/cactus/Converter.scala
+++ b/macros/src/main/scala/com/avast/cactus/Converter.scala
@@ -14,8 +14,6 @@ object Converter {
     override def apply(a: A): B = f(a)
   }
 
-//  implicit def identityConverter[A]: Converter[A, A] = Converter(identity)
-
   // primitive types conversions:
 
   // this converter is necessary otherwise we get strange compilation errors

--- a/macros/src/main/scala/com/avast/cactus/Converter.scala
+++ b/macros/src/main/scala/com/avast/cactus/Converter.scala
@@ -14,6 +14,8 @@ object Converter {
     override def apply(a: A): B = f(a)
   }
 
+//  implicit def identityConverter[A]: Converter[A, A] = Converter(identity)
+
   // primitive types conversions:
 
   // this converter is necessary otherwise we get strange compilation errors
@@ -38,6 +40,8 @@ object Converter {
   implicit val Boolean2booleanConverter: Converter[java.lang.Boolean, Boolean] = Converter(Boolean2boolean)
 
   // collections conversions:
+
+  implicit def vectorToList[A, B](implicit aToBConverter: Converter[A, B]): Converter[Vector[A], List[B]] = Converter(_.map(aToBConverter.apply).toList)
 
   implicit def vectorToList[A]: Converter[Vector[A], List[A]] = Converter(_.toList)
 

--- a/macros/src/main/scala/com/avast/cactus/Converter.scala
+++ b/macros/src/main/scala/com/avast/cactus/Converter.scala
@@ -37,12 +37,11 @@ object Converter {
   implicit val Double2doubleConverter: Converter[java.lang.Double, Double] = Converter(Double2double)
   implicit val Boolean2booleanConverter: Converter[java.lang.Boolean, Boolean] = Converter(Boolean2boolean)
 
-  // collections conversions:
+  // conversions generators:
 
   implicit def vectorToList[A, B](implicit aToBConverter: Converter[A, B]): Converter[Vector[A], List[B]] = Converter(_.map(aToBConverter.apply).toList)
 
   implicit def vectorToList[A]: Converter[Vector[A], List[A]] = Converter(_.toList)
 
   implicit def vectorToArray[A: ClassTag]: Converter[Vector[A], Array[A]] = Converter(_.toArray)
-
 }

--- a/macros/src/main/scala/com/avast/cactus/Converter.scala
+++ b/macros/src/main/scala/com/avast/cactus/Converter.scala
@@ -13,6 +13,8 @@ object Converter {
     override def apply(a: A): B = f(a)
   }
 
+  // primitive types conversions:
+
   // this converter is necessary otherwise we get strange compilation errors
   implicit val string2StringConverter: Converter[String, java.lang.String] = Converter(identity)
 
@@ -33,5 +35,9 @@ object Converter {
   implicit val Float2floatConverter: Converter[java.lang.Float, Float] = Converter(Float2float)
   implicit val Double2doubleConverter: Converter[java.lang.Double, Double] = Converter(Double2double)
   implicit val Boolean2booleanConverter: Converter[java.lang.Boolean, Boolean] = Converter(Boolean2boolean)
+
+  // collections conversions:
+
+  implicit def vectorToList[A]: Converter[Vector[A], List[A]] = Converter(_.toList)
 
 }

--- a/macros/src/main/scala/com/avast/cactus/Converter.scala
+++ b/macros/src/main/scala/com/avast/cactus/Converter.scala
@@ -1,6 +1,7 @@
 package com.avast.cactus
 
 import scala.annotation.implicitNotFound
+import scala.reflect.ClassTag
 
 @implicitNotFound("Could not find an instance of Converter from ${A} to ${B}, try to import or define one")
 trait Converter[A, B] {
@@ -39,5 +40,7 @@ object Converter {
   // collections conversions:
 
   implicit def vectorToList[A]: Converter[Vector[A], List[A]] = Converter(_.toList)
+
+  implicit def vectorToArray[A: ClassTag]: Converter[Vector[A], Array[A]] = Converter(_.toArray)
 
 }

--- a/macros/src/test/scala/com/avast/cactus/CactusMacrosTest.scala
+++ b/macros/src/test/scala/com/avast/cactus/CactusMacrosTest.scala
@@ -1,6 +1,6 @@
 package com.avast.cactus
 
-import com.avast.cactus.TestMessage.{Data, Data2}
+import com.avast.cactus.TestMessage._
 import com.google.protobuf.ByteString
 import org.scalactic.{Bad, Good}
 import org.scalatest.FunSuite
@@ -73,7 +73,7 @@ class CactusMacrosTest extends FunSuite {
   }
 
   test("Case class to GPB") {
-    val caseClass = CaseClassC(StringWrapperClass("ahoj"), 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, List("a", "b"), List(3, 6), List())
+    val caseClass = CaseClassC(StringWrapperClass("ahoj"), 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, Array("a", "b"), List(3, 6), List())
 
     val gpbInternal = Data2.newBuilder()
       .setFieldDouble(0.9)
@@ -98,8 +98,8 @@ class CactusMacrosTest extends FunSuite {
     }
   }
 
-  test("case class to GPB and back") {
-    val original = CaseClassC(StringWrapperClass("ahoj"), 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, List("a", "b"), Vector(3, 6), List())
+  test("convert case class to GPB and back") {
+    val original = CaseClassC(StringWrapperClass("ahoj"), 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, Array("a", "b"), Vector(3, 6), List())
 
     val Good(converted) = original.asGpb[Data]
 
@@ -133,10 +133,31 @@ case class CaseClassC(field: StringWrapperClass,
                       fieldGpb: CaseClassB,
                       fieldGpbOption: Option[CaseClassB],
                       fieldGpbOptionEmpty: Option[CaseClassB],
-                      fieldStrings: Seq[String],
+                      fieldStrings: Array[String],
                       fieldOptionIntegers: Seq[Int],
-                      fieldOptionIntegersEmpty: Seq[Int])
+                      fieldOptionIntegersEmpty: Seq[Int]) {
+
+  // needed because of the array
+  override def equals(obj: scala.Any): Boolean = obj match {
+    case that: CaseClassC =>
+      field == that.field &&
+        fieldInt == that.fieldInt &&
+        fieldOption == that.fieldOption &&
+        fieldBlob == that.fieldBlob &&
+        fieldStrings2 == that.fieldStrings2 &&
+        fieldGpb == that.fieldGpb &&
+        fieldGpbOption == that.fieldGpbOption &&
+        fieldGpbOptionEmpty == that.fieldGpbOptionEmpty &&
+        (fieldStrings sameElements that.fieldStrings) &&
+        fieldOptionIntegers == that.fieldOptionIntegers &&
+        fieldOptionIntegersEmpty == that.fieldOptionIntegersEmpty
+
+    case _ => false
+  }
+}
 
 case class StringWrapperClass(value: String)
 
-object CaseClassA // this is here to prevent reappearing of bug with companion object
+object CaseClassA
+
+// this is here to prevent reappearing of bug with companion object

--- a/macros/src/test/scala/com/avast/cactus/CactusMacrosTest.scala
+++ b/macros/src/test/scala/com/avast/cactus/CactusMacrosTest.scala
@@ -36,7 +36,7 @@ class CactusMacrosTest extends FunSuite {
       .addAllFieldOptionIntegers(Seq(3, 6).map(int2Integer).asJava)
       .build()
 
-    val expected = CaseClassA("ahoj", 9, Some(13), ByteString.EMPTY, List("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, List("a", "b"), Some(Vector(3, 6)), None)
+    val expected = CaseClassA("ahoj", 9, Some(13), ByteString.EMPTY, List("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, List("a", "b"), Vector(3, 6), List())
     assertResult(Good(expected))(gpb.asCaseClass[CaseClassA])
   }
 
@@ -59,7 +59,7 @@ class CactusMacrosTest extends FunSuite {
       .addAllFieldOptionIntegers(Seq(3, 6).map(int2Integer).asJava)
       .build()
 
-    val expected = List("field", "fieldIntName", "fieldStrings").map(MissingFieldFailure).sortBy(_.toString)
+    val expected = List("field", "fieldIntName").map(MissingFieldFailure).sortBy(_.toString)
 
     gpb.asCaseClass[CaseClassA] match {
       case Bad(e) =>
@@ -70,7 +70,7 @@ class CactusMacrosTest extends FunSuite {
   }
 
   test("Case class to GPB") {
-    val caseClass = CaseClassC("ahoj", 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, List("a", "b"), Some(List(3, 6)), None)
+    val caseClass = CaseClassC("ahoj", 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, List("a", "b"), List(3, 6), List())
 
     val gpbInternal = Data2.newBuilder()
       .setFieldDouble(0.9)
@@ -96,7 +96,7 @@ class CactusMacrosTest extends FunSuite {
   }
 
   test("case class to GPB and back") {
-    val original = CaseClassC("ahoj", 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, List("a", "b"), Some(Vector(3, 6)), None)
+    val original = CaseClassC("ahoj", 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, List("a", "b"), Vector(3, 6), List())
 
     val Good(converted) = original.asGpb[Data]
 
@@ -115,8 +115,8 @@ case class CaseClassA(field: String,
                       fieldGpbOption: Option[CaseClassB],
                       fieldGpbOptionEmpty: Option[CaseClassB],
                       fieldStrings: immutable.Seq[String],
-                      fieldOptionIntegers: Option[Vector[Int]],
-                      fieldOptionIntegersEmpty: Option[List[Int]])
+                      fieldOptionIntegers: Vector[Int],
+                      fieldOptionIntegersEmpty: List[Int])
 
 case class CaseClassB(fieldDouble: Double, @GpbName("fieldBlob") fieldString: String)
 
@@ -132,5 +132,5 @@ case class CaseClassC(field: String,
                       fieldGpbOption: Option[CaseClassB],
                       fieldGpbOptionEmpty: Option[CaseClassB],
                       fieldStrings: Seq[String],
-                      fieldOptionIntegers: Option[Seq[Int]],
-                      fieldOptionIntegersEmpty: Option[Seq[Int]])
+                      fieldOptionIntegers: Seq[Int],
+                      fieldOptionIntegersEmpty: Seq[Int])

--- a/macros/src/test/scala/com/avast/cactus/CactusMacrosTest.scala
+++ b/macros/src/test/scala/com/avast/cactus/CactusMacrosTest.scala
@@ -133,8 +133,8 @@ case class CaseClassC(field: StringWrapperClass,
                       fieldGpb: CaseClassB,
                       fieldGpbOption: Option[CaseClassB],
                       fieldGpbOptionEmpty: Option[CaseClassB],
-                      fieldStrings: List[Double],
-                      fieldOptionIntegers: String,
+                      fieldStrings: Seq[String],
+                      fieldOptionIntegers: Seq[Int],
                       fieldOptionIntegersEmpty: Seq[Int])
 
 case class StringWrapperClass(value: String)

--- a/macros/src/test/scala/com/avast/cactus/CactusMacrosTest.scala
+++ b/macros/src/test/scala/com/avast/cactus/CactusMacrosTest.scala
@@ -14,9 +14,9 @@ class CactusMacrosTest extends FunSuite {
   implicit val StringToByteStringConverter: Converter[String, ByteString] = Converter((b: String) => ByteString.copyFromUtf8(b))
   implicit val ByteStringToStringConverter: Converter[ByteString, String] = Converter((b: ByteString) => b.toStringUtf8)
 
-  // these are not needed, but they are here to be sure it won't cause trouble to the user
-  implicit val ByteArrayToByteStringConverter: Converter[Array[Byte], ByteString] = Converter((b: Array[Byte]) => ByteString.copyFrom(b))
-  implicit val ByteStringToByteArrayConverter: Converter[ByteString, Array[Byte]] = Converter((b: ByteString) => b.toByteArray)
+  implicit def vectorToString[A]: Converter[Vector[A], String] = Converter(_.mkString(","))
+
+  implicit def stringToVectorInt: Converter[String, Vector[Integer]] = Converter(_.split(",").map(_.toInt).map(int2Integer).toVector)
 
   test("GPB to case class") {
     val gpbInternal = Data2.newBuilder()
@@ -70,7 +70,7 @@ class CactusMacrosTest extends FunSuite {
   }
 
   test("Case class to GPB") {
-    val caseClass = CaseClassC("ahoj", 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, List("a", "b"), List(3, 6), List())
+    val caseClass = CaseClassC("ahoj", 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, List("a", "b"), "3,6", List())
 
     val gpbInternal = Data2.newBuilder()
       .setFieldDouble(0.9)
@@ -96,7 +96,7 @@ class CactusMacrosTest extends FunSuite {
   }
 
   test("case class to GPB and back") {
-    val original = CaseClassC("ahoj", 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, List("a", "b"), Vector(3, 6), List())
+    val original = CaseClassC("ahoj", 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, Vector("a", "b"), "3,6", Vector())
 
     val Good(converted) = original.asGpb[Data]
 
@@ -132,5 +132,5 @@ case class CaseClassC(field: String,
                       fieldGpbOption: Option[CaseClassB],
                       fieldGpbOptionEmpty: Option[CaseClassB],
                       fieldStrings: Seq[String],
-                      fieldOptionIntegers: Seq[Int],
+                      fieldOptionIntegers: String,
                       fieldOptionIntegersEmpty: Seq[Int])

--- a/macros/src/test/scala/com/avast/cactus/CactusMacrosTest.scala
+++ b/macros/src/test/scala/com/avast/cactus/CactusMacrosTest.scala
@@ -14,9 +14,13 @@ class CactusMacrosTest extends FunSuite {
   implicit val StringToByteStringConverter: Converter[String, ByteString] = Converter((b: String) => ByteString.copyFromUtf8(b))
   implicit val ByteStringToStringConverter: Converter[ByteString, String] = Converter((b: ByteString) => b.toStringUtf8)
 
+  implicit val doubleToStringConverter: Converter[Double, String] = Converter(_.toString)
+  //TODO improve message
+  implicit val stringToDoubleConverter: Converter[String, Double] = Converter(_.toDouble)
+
   implicit def vectorToString[A]: Converter[Vector[A], String] = Converter(_.mkString(","))
 
-  implicit def stringToVectorInt: Converter[String, Vector[Integer]] = Converter(_.split(",").map(_.toInt).map(int2Integer).toVector)
+  implicit val stringToVectorInt: Converter[String, Vector[Integer]] = Converter(_.split(",").map(_.toInt).map(int2Integer).toVector)
 
   test("GPB to case class") {
     val gpbInternal = Data2.newBuilder()
@@ -70,7 +74,7 @@ class CactusMacrosTest extends FunSuite {
   }
 
   test("Case class to GPB") {
-    val caseClass = CaseClassC("ahoj", 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, List("a", "b"), "3,6", List())
+    val caseClass = CaseClassC("ahoj", 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, List(3.5, 6.7), "3,6", List())
 
     val gpbInternal = Data2.newBuilder()
       .setFieldDouble(0.9)
@@ -96,7 +100,7 @@ class CactusMacrosTest extends FunSuite {
   }
 
   test("case class to GPB and back") {
-    val original = CaseClassC("ahoj", 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, Vector("a", "b"), "3,6", Vector())
+    val original = CaseClassC("ahoj", 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, List(3.5, 6.7), "3,6", Vector())
 
     val Good(converted) = original.asGpb[Data]
 
@@ -131,6 +135,6 @@ case class CaseClassC(field: String,
                       fieldGpb: CaseClassB,
                       fieldGpbOption: Option[CaseClassB],
                       fieldGpbOptionEmpty: Option[CaseClassB],
-                      fieldStrings: Seq[String],
+                      fieldStrings: List[Double],
                       fieldOptionIntegers: String,
                       fieldOptionIntegersEmpty: Seq[Int])


### PR DESCRIPTION
Collections are converted to `Vector` and anything else has to be solved by converters. There are prepared converters `Vector -> List` and `Vector -> Array`. It's also possible to convert original collection (like `Vector[Integer]`) to foreign data type (basically anything).
