### PR TITLE
Variable path tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Library for mapping between [GPB](https://developers.google.com/protocol-buffers
 The library automatically converts common data types (`String`, primitive types, collections) and can map optional fields 
 into `Option`. This process is extensible via `Converter`.
 
+From version 0.8, the whole variable path (e.g. _gpb.fieldGpb2RepeatedRecurse.fieldGpb.fieldBlob_) is reported in case of failure.
+
 ## GPB to case class
 
 We often need to map GPB message to business object (which is usually a case class) when GPB is used for communication 

--- a/macros/src/main/scala/com/avast/cactus/CactusMacros.scala
+++ b/macros/src/main/scala/com/avast/cactus/CactusMacros.scala
@@ -70,9 +70,6 @@ object CactusMacros {
 
     val variableName = variable.symbol.asTerm.fullName.split('.').last
 
-    //    c.abort(c.enclosingPosition, s"NAME=$variableName")
-
-
     c.Expr[CaseClass Or Every[CactusFailure]] {
       val caseClassType = weakTypeOf[CaseClass]
       val gpbType = gpbSymbol.typeSignature.asInstanceOf[c.universe.Type]
@@ -238,7 +235,7 @@ object CactusMacros {
           val wrappedDstType = wrapDstType(c)(dstTypeArg)
 
           newConverter(c)(srcResultType, wrappedDstType) {
-            q" (fieldPath: String) => (t: $srcResultType) => ${processEndType(c)(fieldName, c.Expr[String](q"fieldPath"), fieldAnnotations, nameInGpb, dstTypeArg)(None, q" t ", getterReturnType)} "
+            q" (fieldPath: String, t: $srcResultType) => ${processEndType(c)(fieldName, c.Expr[String](q"fieldPath"), fieldAnnotations, nameInGpb, dstTypeArg)(None, q" t ", getterReturnType)} "
           }
 
           query match {
@@ -268,7 +265,7 @@ object CactusMacros {
           val wrappedDstType = wrapDstType(c)(dstResultType)
 
           newConverter(c)(srcResultType, wrappedDstType) {
-            q" (fieldPath: String) => (t: $srcResultType) => ${createConverter(c)(c.Expr[String](q"fieldPath"), returnType, getterReturnType, q" t ")} "
+            q" (fieldPath: String, t: $srcResultType) => ${createConverter(c)(c.Expr[String](q"fieldPath"), returnType, getterReturnType, q" t ")} "
           }
 
           val value = q" CactusMacros.AToB[$srcResultType, $wrappedDstType]($fieldPath)($getter) "
@@ -309,7 +306,7 @@ object CactusMacros {
                 val wrappedDstType = CactusMacros.GpbToCaseClass.wrapDstType(c)(dstKeyType)
 
                 newConverter(c)(srcKeyType, wrappedDstType) {
-                  q" (fieldPath: String) => (t: $srcKeyType) => ${processEndType(c)(TermName("key"), c.Expr[String](q"fieldPath"), Map(), "nameInGpb", dstKeyType)(None, q" t ", srcKeyType)} "
+                  q" (fieldPath: String, t: $srcKeyType) => ${processEndType(c)(TermName("key"), c.Expr[String](q"fieldPath"), Map(), "nameInGpb", dstKeyType)(None, q" t ", srcKeyType)} "
                 }
 
                 q" CactusMacros.AToB[$srcKeyType, $wrappedDstType]($fieldPath)(f.$getKeyField) "
@@ -321,7 +318,7 @@ object CactusMacros {
                 val wrappedDstType = CactusMacros.GpbToCaseClass.wrapDstType(c)(dstValueType)
 
                 newConverter(c)(srcValueType, wrappedDstType) {
-                  q" (fieldPath: String) => (t: $srcValueType) => ${processEndType(c)(TermName("key"), c.Expr[String](q"fieldPath"), Map(), "nameInGpb", dstValueType)(None, q" t ", srcValueType)} "
+                  q" (fieldPath: String, t: $srcValueType) => ${processEndType(c)(TermName("key"), c.Expr[String](q"fieldPath"), Map(), "nameInGpb", dstValueType)(None, q" t ", srcValueType)} "
                 }
 
                 q" CactusMacros.AToB[$srcValueType, $wrappedDstType]($fieldPath)(f.$getValueField) "
@@ -330,7 +327,7 @@ object CactusMacros {
               val wrappedDstType = wrapDstType(c)(dstResultType)
 
               newConverter(c)(srcResultType, wrappedDstType) {
-                q""" (fieldPath: String) => (a: $srcResultType) => {
+                q""" (fieldPath: String, a: $srcResultType) => {
                           a.asScala
                             .map(f => $keyField -> $valueField)
                             .toSeq.map{ case(key, or) => withGood(key, or)(_ -> _) }.combined.map(_.toMap)
@@ -383,7 +380,7 @@ object CactusMacros {
                   val wrappedDstTypeArg = wrapDstType(c)(dstTypeArg)
 
                   newConverter(c)(srcTypeArg, wrappedDstTypeArg) {
-                    q" (fieldPath: String) => (a: $srcTypeArg) =>  { ${processEndType(c)(fieldName, c.Expr[String](q"fieldPath"), fieldAnnotations, nameInGpb, dstTypeArg)(None, q" a ", srcTypeArg)} } "
+                    q" (fieldPath: String, a: $srcTypeArg) =>  { ${processEndType(c)(fieldName, c.Expr[String](q"fieldPath"), fieldAnnotations, nameInGpb, dstTypeArg)(None, q" a ", srcTypeArg)} } "
                   }
 
                   q" $getter.asScala.map(CactusMacros.AToB[$srcTypeArg, $wrappedDstTypeArg]($fieldPath)).toVector.combined.map($toFinalCollection) "

--- a/macros/src/main/scala/com/avast/cactus/Converter.scala
+++ b/macros/src/main/scala/com/avast/cactus/Converter.scala
@@ -8,45 +8,45 @@ import scala.reflect.ClassTag
 
 @implicitNotFound("Could not find an instance of Converter from ${A} to ${B}, try to import or define one")
 trait Converter[A, B] {
-  def apply(a: A): B
+  def apply(fieldPath: String)(a: A): B
 }
 
 object Converter extends V3Converters with OptionalConverters {
 
-  def apply[A, B](f: A => B): Converter[A, B] = new Converter[A, B] {
-    override def apply(a: A): B = f(a)
+  def apply[A, B](f: String => A => B): Converter[A, B] = new Converter[A, B] {
+    override def apply(fieldPath: String)(a: A): B = f(fieldPath)(a)
   }
 
   // primitive types conversions:
 
   // this converter is necessary otherwise we get strange compilation errors
-  implicit val string2StringConverter: Converter[String, java.lang.String] = Converter(identity)
+  implicit val string2StringConverter: Converter[String, java.lang.String] = Converter( _ => identity)
 
-  implicit val byte2ByteConverter: Converter[Byte, java.lang.Byte] = Converter(byte2Byte)
-  implicit val short2ShortConverter: Converter[Short, java.lang.Short] = Converter(short2Short)
-  implicit val char2CharacterConverter: Converter[Char, java.lang.Character] = Converter(char2Character)
-  implicit val int2IntegerConverter: Converter[Int, java.lang.Integer] = Converter(int2Integer)
-  implicit val long2LongConverter: Converter[Long, java.lang.Long] = Converter(long2Long)
-  implicit val float2FloatConverter: Converter[Float, java.lang.Float] = Converter(float2Float)
-  implicit val double2DoubleConverter: Converter[Double, java.lang.Double] = Converter(double2Double)
-  implicit val boolean2BooleanConverter: Converter[Boolean, java.lang.Boolean] = Converter(boolean2Boolean)
+  implicit val byte2ByteConverter: Converter[Byte, java.lang.Byte] = Converter(_ => byte2Byte)
+  implicit val short2ShortConverter: Converter[Short, java.lang.Short] = Converter(_ => short2Short)
+  implicit val char2CharacterConverter: Converter[Char, java.lang.Character] = Converter(_ => char2Character)
+  implicit val int2IntegerConverter: Converter[Int, java.lang.Integer] = Converter(_ => int2Integer)
+  implicit val long2LongConverter: Converter[Long, java.lang.Long] = Converter(_ => long2Long)
+  implicit val float2FloatConverter: Converter[Float, java.lang.Float] = Converter(_ => float2Float)
+  implicit val double2DoubleConverter: Converter[Double, java.lang.Double] = Converter(_ => double2Double)
+  implicit val boolean2BooleanConverter: Converter[Boolean, java.lang.Boolean] = Converter(_ => boolean2Boolean)
 
-  implicit val Byte2byteConverter: Converter[java.lang.Byte, Byte] = Converter(Byte2byte)
-  implicit val Short2shortConverter: Converter[java.lang.Short, Short] = Converter(Short2short)
-  implicit val Character2charConverter: Converter[java.lang.Character, Char] = Converter(Character2char)
-  implicit val Integer2intConverter: Converter[java.lang.Integer, Int] = Converter(Integer2int)
-  implicit val Long2longConverter: Converter[java.lang.Long, Long] = Converter(Long2long)
-  implicit val Float2floatConverter: Converter[java.lang.Float, Float] = Converter(Float2float)
-  implicit val Double2doubleConverter: Converter[java.lang.Double, Double] = Converter(Double2double)
-  implicit val Boolean2booleanConverter: Converter[java.lang.Boolean, Boolean] = Converter(Boolean2boolean)
+  implicit val Byte2byteConverter: Converter[java.lang.Byte, Byte] = Converter(_ => Byte2byte)
+  implicit val Short2shortConverter: Converter[java.lang.Short, Short] = Converter(_ => Short2short)
+  implicit val Character2charConverter: Converter[java.lang.Character, Char] = Converter(_ => Character2char)
+  implicit val Integer2intConverter: Converter[java.lang.Integer, Int] = Converter(_ => Integer2int)
+  implicit val Long2longConverter: Converter[java.lang.Long, Long] = Converter(_ => Long2long)
+  implicit val Float2floatConverter: Converter[java.lang.Float, Float] = Converter(_ => Float2float)
+  implicit val Double2doubleConverter: Converter[java.lang.Double, Double] = Converter(_ => Double2double)
+  implicit val Boolean2booleanConverter: Converter[java.lang.Boolean, Boolean] = Converter(_ => Boolean2boolean)
 
   // v3 conversions inherited from V3Converters
 
   // conversions generators:
 
-  implicit def vectorToList[A, B](implicit aToBConverter: Converter[A, B]): Converter[Vector[A], List[B]] = Converter(_.map(aToBConverter.apply).toList)
+  implicit def vectorToList[A, B](implicit aToBConverter: Converter[A, B]): Converter[Vector[A], List[B]] = Converter(fp => _.map(aToBConverter.apply(fp)).toList)
 
-  implicit def vectorToList[A]: Converter[Vector[A], List[A]] = Converter(_.toList)
+  implicit def vectorToList[A]: Converter[Vector[A], List[A]] = Converter(_ => _.toList)
 
-  implicit def vectorToArray[A: ClassTag]: Converter[Vector[A], Array[A]] = Converter(_.toArray)
+  implicit def vectorToArray[A: ClassTag]: Converter[Vector[A], Array[A]] = Converter(_ => _.toArray)
 }

--- a/macros/src/main/scala/com/avast/cactus/Converter.scala
+++ b/macros/src/main/scala/com/avast/cactus/Converter.scala
@@ -1,6 +1,8 @@
 package com.avast.cactus
 
 import com.avast.cactus.v3.V3Converters
+import org.scalactic.Good
+import org.scalactic.Accumulation._
 
 import scala.annotation.implicitNotFound
 import scala.collection.JavaConverters._
@@ -8,17 +10,17 @@ import scala.reflect.ClassTag
 
 @implicitNotFound("Could not find an instance of Converter from ${A} to ${B}, try to import or define one")
 trait Converter[A, B] {
-  def apply(fieldPath: String)(a: A): B
+  def apply(fieldPath: String)(a: A): ResultOrError[B]
 }
 
 object Converter extends V3Converters with OptionalConverters {
 
-  def apply[A, B](f: (String, A) => ResultOrError[B]): Converter[A, ResultOrError[B]] = new Converter[A, ResultOrError[B]] {
+  def checked[A, B](f: (String, A) => ResultOrError[B]): Converter[A, B] = new Converter[A, B] {
     override def apply(fieldPath: String)(a: A): ResultOrError[B] = f(fieldPath, a)
   }
 
   def apply[A, B](f: A => B): Converter[A, B] = new Converter[A, B] {
-    override def apply(fieldPath: String)(a: A): B = f(a)
+    override def apply(fieldPath: String)(a: A): ResultOrError[B] = Good(f(a))
   }
 
   // primitive types conversions:
@@ -49,8 +51,8 @@ object Converter extends V3Converters with OptionalConverters {
   // conversions generators:
 
   implicit def vectorToList[A, B](implicit aToBConverter: Converter[A, B]): Converter[Vector[A], List[B]] = new Converter[Vector[A], List[B]] {
-    override def apply(fieldPath: String)(v: Vector[A]): List[B] = {
-      v.map(aToBConverter.apply(fieldPath)).toList
+    override def apply(fieldPath: String)(v: Vector[A]): ResultOrError[List[B]] = {
+      v.map(aToBConverter.apply(fieldPath)).toList.combined
     }
   }
 

--- a/macros/src/main/scala/com/avast/cactus/Converter.scala
+++ b/macros/src/main/scala/com/avast/cactus/Converter.scala
@@ -13,40 +13,48 @@ trait Converter[A, B] {
 
 object Converter extends V3Converters with OptionalConverters {
 
-  def apply[A, B](f: String => A => B): Converter[A, B] = new Converter[A, B] {
-    override def apply(fieldPath: String)(a: A): B = f(fieldPath)(a)
+  def apply[A, B](f: (String, A) => ResultOrError[B]): Converter[A, ResultOrError[B]] = new Converter[A, ResultOrError[B]] {
+    override def apply(fieldPath: String)(a: A): ResultOrError[B] = f(fieldPath, a)
+  }
+
+  def apply[A, B](f: A => B): Converter[A, B] = new Converter[A, B] {
+    override def apply(fieldPath: String)(a: A): B = f(a)
   }
 
   // primitive types conversions:
 
   // this converter is necessary otherwise we get strange compilation errors
-  implicit val string2StringConverter: Converter[String, java.lang.String] = Converter( _ => identity)
+  implicit val string2StringConverter: Converter[String, java.lang.String] = Converter(identity)
 
-  implicit val byte2ByteConverter: Converter[Byte, java.lang.Byte] = Converter(_ => byte2Byte)
-  implicit val short2ShortConverter: Converter[Short, java.lang.Short] = Converter(_ => short2Short)
-  implicit val char2CharacterConverter: Converter[Char, java.lang.Character] = Converter(_ => char2Character)
-  implicit val int2IntegerConverter: Converter[Int, java.lang.Integer] = Converter(_ => int2Integer)
-  implicit val long2LongConverter: Converter[Long, java.lang.Long] = Converter(_ => long2Long)
-  implicit val float2FloatConverter: Converter[Float, java.lang.Float] = Converter(_ => float2Float)
-  implicit val double2DoubleConverter: Converter[Double, java.lang.Double] = Converter(_ => double2Double)
-  implicit val boolean2BooleanConverter: Converter[Boolean, java.lang.Boolean] = Converter(_ => boolean2Boolean)
+  implicit val byte2ByteConverter: Converter[Byte, java.lang.Byte] = Converter(byte2Byte)
+  implicit val short2ShortConverter: Converter[Short, java.lang.Short] = Converter(short2Short)
+  implicit val char2CharacterConverter: Converter[Char, java.lang.Character] = Converter(char2Character)
+  implicit val int2IntegerConverter: Converter[Int, java.lang.Integer] = Converter(int2Integer)
+  implicit val long2LongConverter: Converter[Long, java.lang.Long] = Converter(long2Long)
+  implicit val float2FloatConverter: Converter[Float, java.lang.Float] = Converter(float2Float)
+  implicit val double2DoubleConverter: Converter[Double, java.lang.Double] = Converter(double2Double)
+  implicit val boolean2BooleanConverter: Converter[Boolean, java.lang.Boolean] = Converter(boolean2Boolean)
 
-  implicit val Byte2byteConverter: Converter[java.lang.Byte, Byte] = Converter(_ => Byte2byte)
-  implicit val Short2shortConverter: Converter[java.lang.Short, Short] = Converter(_ => Short2short)
-  implicit val Character2charConverter: Converter[java.lang.Character, Char] = Converter(_ => Character2char)
-  implicit val Integer2intConverter: Converter[java.lang.Integer, Int] = Converter(_ => Integer2int)
-  implicit val Long2longConverter: Converter[java.lang.Long, Long] = Converter(_ => Long2long)
-  implicit val Float2floatConverter: Converter[java.lang.Float, Float] = Converter(_ => Float2float)
-  implicit val Double2doubleConverter: Converter[java.lang.Double, Double] = Converter(_ => Double2double)
-  implicit val Boolean2booleanConverter: Converter[java.lang.Boolean, Boolean] = Converter(_ => Boolean2boolean)
+  implicit val Byte2byteConverter: Converter[java.lang.Byte, Byte] = Converter(Byte2byte)
+  implicit val Short2shortConverter: Converter[java.lang.Short, Short] = Converter(Short2short)
+  implicit val Character2charConverter: Converter[java.lang.Character, Char] = Converter(Character2char)
+  implicit val Integer2intConverter: Converter[java.lang.Integer, Int] = Converter(Integer2int)
+  implicit val Long2longConverter: Converter[java.lang.Long, Long] = Converter(Long2long)
+  implicit val Float2floatConverter: Converter[java.lang.Float, Float] = Converter(Float2float)
+  implicit val Double2doubleConverter: Converter[java.lang.Double, Double] = Converter(Double2double)
+  implicit val Boolean2booleanConverter: Converter[java.lang.Boolean, Boolean] = Converter(Boolean2boolean)
 
   // v3 conversions inherited from V3Converters
 
   // conversions generators:
 
-  implicit def vectorToList[A, B](implicit aToBConverter: Converter[A, B]): Converter[Vector[A], List[B]] = Converter(fp => _.map(aToBConverter.apply(fp)).toList)
+  implicit def vectorToList[A, B](implicit aToBConverter: Converter[A, B]): Converter[Vector[A], List[B]] = new Converter[Vector[A], List[B]] {
+    override def apply(fieldPath: String)(v: Vector[A]): List[B] = {
+      v.map(aToBConverter.apply(fieldPath)).toList
+    }
+  }
 
-  implicit def vectorToList[A]: Converter[Vector[A], List[A]] = Converter(_ => _.toList)
+  implicit def vectorToList[A]: Converter[Vector[A], List[A]] = Converter(_.toList)
 
-  implicit def vectorToArray[A: ClassTag]: Converter[Vector[A], Array[A]] = Converter(_ => _.toArray)
+  implicit def vectorToArray[A: ClassTag]: Converter[Vector[A], Array[A]] = Converter(_.toArray)
 }

--- a/macros/src/main/scala/com/avast/cactus/OptionalConverters.scala
+++ b/macros/src/main/scala/com/avast/cactus/OptionalConverters.scala
@@ -5,20 +5,20 @@ import com.avast.bytes.gpb.ByteStringBytes
 import com.google.protobuf.{ByteString, BytesValue}
 
 trait OptionalConverters {
-  implicit val BytesToByteStringConverter: Converter[Bytes, ByteString] = Converter {
+  implicit val BytesToByteStringConverter: Converter[Bytes, ByteString] = Converter {_ =>{
     case b: ByteStringBytes => b.underlying()
-    case b: Bytes => ByteString.copyFrom(b.toReadOnlyByteBuffer)
+    case b: Bytes => ByteString.copyFrom(b.toReadOnlyByteBuffer)}
   }
 
-  implicit val ByteStringToBytesConverter: Converter[ByteString, Bytes] = Converter((b: ByteString) => ByteStringBytes.wrap(b))
+  implicit val ByteStringToBytesConverter: Converter[ByteString, Bytes] = Converter(_ => (b: ByteString) => ByteStringBytes.wrap(b))
 
   // v3:
 
-  implicit val bytes2bytesValue: Converter[Bytes, BytesValue] = Converter {
+  implicit val bytes2bytesValue: Converter[Bytes, BytesValue] = Converter {_ =>{
     case b: ByteStringBytes => BytesValue.newBuilder().setValue(b.underlying()).build()
-    case b: Bytes => BytesValue.newBuilder().setValue(ByteString.copyFrom(b.toReadOnlyByteBuffer)).build()
+    case b: Bytes => BytesValue.newBuilder().setValue(ByteString.copyFrom(b.toReadOnlyByteBuffer)).build()}
   }
 
-  implicit val bytesValue2Bytes: Converter[BytesValue, Bytes] = Converter(v => ByteStringBytes.wrap(v.getValue))
+  implicit val bytesValue2Bytes: Converter[BytesValue, Bytes] = Converter(_ =>v => ByteStringBytes.wrap(v.getValue))
 
 }

--- a/macros/src/main/scala/com/avast/cactus/OptionalConverters.scala
+++ b/macros/src/main/scala/com/avast/cactus/OptionalConverters.scala
@@ -5,20 +5,20 @@ import com.avast.bytes.gpb.ByteStringBytes
 import com.google.protobuf.{ByteString, BytesValue}
 
 trait OptionalConverters {
-  implicit val BytesToByteStringConverter: Converter[Bytes, ByteString] = Converter {_ =>{
+  implicit val BytesToByteStringConverter: Converter[Bytes, ByteString] = Converter {
     case b: ByteStringBytes => b.underlying()
-    case b: Bytes => ByteString.copyFrom(b.toReadOnlyByteBuffer)}
+    case b: Bytes => ByteString.copyFrom(b.toReadOnlyByteBuffer)
   }
 
-  implicit val ByteStringToBytesConverter: Converter[ByteString, Bytes] = Converter(_ => (b: ByteString) => ByteStringBytes.wrap(b))
+  implicit val ByteStringToBytesConverter: Converter[ByteString, Bytes] = Converter((b: ByteString) => ByteStringBytes.wrap(b))
 
   // v3:
 
-  implicit val bytes2bytesValue: Converter[Bytes, BytesValue] = Converter {_ =>{
+  implicit val bytes2bytesValue: Converter[Bytes, BytesValue] = Converter {
     case b: ByteStringBytes => BytesValue.newBuilder().setValue(b.underlying()).build()
-    case b: Bytes => BytesValue.newBuilder().setValue(ByteString.copyFrom(b.toReadOnlyByteBuffer)).build()}
+    case b: Bytes => BytesValue.newBuilder().setValue(ByteString.copyFrom(b.toReadOnlyByteBuffer)).build()
   }
 
-  implicit val bytesValue2Bytes: Converter[BytesValue, Bytes] = Converter(_ =>v => ByteStringBytes.wrap(v.getValue))
+  implicit val bytesValue2Bytes: Converter[BytesValue, Bytes] = Converter(v => ByteStringBytes.wrap(v.getValue))
 
 }

--- a/macros/src/main/scala/com/avast/cactus/ProtoVersion.scala
+++ b/macros/src/main/scala/com/avast/cactus/ProtoVersion.scala
@@ -83,7 +83,7 @@ private[cactus] object ProtoVersion {
         val ctorType = getCtorParamType(c)(ccl)
         val value = CactusMacros.convertIfNeeded(c)(c.Expr[String](q"fieldPath"),getter.returnType, ctorType)(q"wholeGpb.$getter")
 
-        cq""" $enumClass.$enum => Good(${ccl.companion}.apply($value))  """
+        cq""" $enumClass.$enum => $value.map(${ccl.companion}.apply)  """
       } :+
         cq""" $enumClass.${TermName(name.toUpperCase + "_NOT_SET")} => Bad(One(OneOfValueNotSetFailure(fieldPath + "." + $name))) """
 

--- a/macros/src/main/scala/com/avast/cactus/ProtoVersion.scala
+++ b/macros/src/main/scala/com/avast/cactus/ProtoVersion.scala
@@ -89,7 +89,7 @@ private[cactus] object ProtoVersion {
 
       val f =
         q""" {
-             (fieldPath: String) => (wholeGpb: $from) => wholeGpb.$getCaseMethod match {
+             (fieldPath: String, wholeGpb: $from) => wholeGpb.$getCaseMethod match {
                 case ..$cases
              }
         }
@@ -142,7 +142,7 @@ private[cactus] object ProtoVersion {
       }
 
       val f =
-        q""" (fieldPath: String) => (field: $classType) => {
+        q""" (fieldPath: String, field: $classType) => {
           field match {
             case ..$cases
           }
@@ -180,7 +180,7 @@ private[cactus] object ProtoVersion {
         q" key "
       } else {
         newConverter(c)(srcKeyType, dstKeyType) {
-          q" (fieldPath: String) => (a: $srcKeyType) => ${CactusMacros.CaseClassToGpb.processEndType(c)(q"a", Map(), srcKeyType)(dstKeyType, q" identity  ", "")} "
+          q" (fieldPath: String, a: $srcKeyType) => ${CactusMacros.CaseClassToGpb.processEndType(c)(q"a", Map(), srcKeyType)(dstKeyType, q" identity  ", "")} "
         }
 
         q" CactusMacros.AToB[$srcKeyType, $dstKeyType](fieldPath)(key) "
@@ -190,14 +190,14 @@ private[cactus] object ProtoVersion {
         q" value "
       } else {
         newConverter(c)(srcValueType, dstValueType) {
-          q" (fieldPath: String) => (a: $srcValueType) => ${CactusMacros.CaseClassToGpb.processEndType(c)(q"a", Map(), srcValueType)(dstValueType, q" identity  ", "")} "
+          q" (fieldPath: String, a: $srcValueType) => ${CactusMacros.CaseClassToGpb.processEndType(c)(q"a", Map(), srcValueType)(dstValueType, q" identity  ", "")} "
         }
 
         q" CactusMacros.AToB[$srcValueType, $dstValueType](fieldPath)(value) "
       }
 
       q"""
-            (fieldPath: String) => (sm: $srcType) => {
+            (fieldPath: String, sm: $srcType) => {
                 val map: Map[$dstKeyType, $dstValueType] = sm.map { case (key, value) =>
                     $keyField -> $valueField
                 }
@@ -224,7 +224,7 @@ private[cactus] object ProtoVersion {
         val wrappedDstType = CactusMacros.GpbToCaseClass.wrapDstType(c)(dstKeyType)
 
         newConverter(c)(srcKeyType, wrappedDstType) {
-          q" (fieldPath: String) => (t: $srcKeyType) => ${CactusMacros.GpbToCaseClass.processEndType(c)(TermName("key"),c.Expr[String](q"fieldPath"), Map(), "nameInGpb", dstKeyType)(None, q" t ", srcKeyType)} "
+          q" (fieldPath: String, t: $srcKeyType) => ${CactusMacros.GpbToCaseClass.processEndType(c)(TermName("key"),c.Expr[String](q"fieldPath"), Map(), "nameInGpb", dstKeyType)(None, q" t ", srcKeyType)} "
         }
 
         q" CactusMacros.AToB[$srcKeyType, $wrappedDstType](fieldPath)(key) "
@@ -236,14 +236,14 @@ private[cactus] object ProtoVersion {
         val wrappedDstType = CactusMacros.GpbToCaseClass.wrapDstType(c)(dstValueType)
 
         newConverter(c)(srcValueType, wrappedDstType) {
-          q" (fieldPath: String) => (t: $srcValueType) => ${CactusMacros.GpbToCaseClass.processEndType(c)(TermName("key"),c.Expr[String](q"fieldPath"), Map(), "nameInGpb", dstValueType)(None, q" t ", srcValueType)} "
+          q" (fieldPath: String, t: $srcValueType) => ${CactusMacros.GpbToCaseClass.processEndType(c)(TermName("key"),c.Expr[String](q"fieldPath"), Map(), "nameInGpb", dstValueType)(None, q" t ", srcValueType)} "
         }
 
         q" CactusMacros.AToB[$srcValueType, $wrappedDstType](fieldPath)(value) "
       }
 
       q"""
-            (fieldPath: String) => (sm: $srcType) => {
+            (fieldPath: String, sm: $srcType) => {
                 sm.asScala.map { case (key, value) =>
                     $keyField -> $valueField
                 }.toSeq.map{ case(key, or) => withGood(key, or)(_ -> _) }.combined.map(_.toMap)

--- a/macros/src/main/scala/com/avast/cactus/cactus.scala
+++ b/macros/src/main/scala/com/avast/cactus/cactus.scala
@@ -9,6 +9,9 @@ import scala.reflect.ClassTag
 
 package object cactus {
 
+  type CactusFailures = org.scalactic.Every[CactusFailure]
+  type ResultOrError[A] = A Or CactusFailures
+
   implicit class GpbToCaseClassConverter[Gpb <: MessageLite](val gpb: Gpb) extends AnyVal {
     def asCaseClass[CaseClass](implicit gpbCt: ClassTag[Gpb]): CaseClass Or Every[CactusFailure] = macro CactusMacros.convertGpbToCaseClass[CaseClass]
   }

--- a/macros/src/main/scala/com/avast/cactus/v3/V3Converters.scala
+++ b/macros/src/main/scala/com/avast/cactus/v3/V3Converters.scala
@@ -8,43 +8,49 @@ import com.google.protobuf.{Duration => GpbDuration, Timestamp => GpbTimestamp, 
 import scala.collection.JavaConverters._
 
 trait V3Converters {
-  implicit val listValue2SeqConverter: Converter[com.google.protobuf.ListValue, Seq[ValueOneOf]] = Converter { listValue =>
-    listValue.getValuesList.asScala.map(ValueOneOf.apply)
+  implicit val listValue2SeqConverter: Converter[com.google.protobuf.ListValue, Seq[ValueOneOf]] = Converter { _ =>
+    listValue =>
+      listValue.getValuesList.asScala.map(ValueOneOf.apply)
   }
 
-  implicit val seq2ListValueConverter: Converter[Seq[ValueOneOf], com.google.protobuf.ListValue] = Converter { values =>
-    ListValue.newBuilder().addAllValues(values.map(ValueOneOf.toGpbValue).asJava).build()
+  implicit val seq2ListValueConverter: Converter[Seq[ValueOneOf], com.google.protobuf.ListValue] = Converter { _ =>
+    values =>
+      ListValue.newBuilder().addAllValues(values.map(ValueOneOf.toGpbValue).asJava).build()
   }
 
-  implicit val struct2MapConverter: Converter[com.google.protobuf.Struct, Map[String, ValueOneOf]] = Converter { struct =>
-    struct.getFieldsMap.asScala.mapValues(ValueOneOf.apply).toMap
+  implicit val struct2MapConverter: Converter[com.google.protobuf.Struct, Map[String, ValueOneOf]] = Converter { _ =>
+    struct =>
+      struct.getFieldsMap.asScala.mapValues(ValueOneOf.apply).toMap
   }
 
-  implicit val map2StructConverter: Converter[Map[String, ValueOneOf], com.google.protobuf.Struct] = Converter { m =>
-    Struct.newBuilder().putAllFields(m.mapValues(ValueOneOf.toGpbValue).asJava).build()
+  implicit val map2StructConverter: Converter[Map[String, ValueOneOf], com.google.protobuf.Struct] = Converter { _ =>
+    m =>
+      Struct.newBuilder().putAllFields(m.mapValues(ValueOneOf.toGpbValue).asJava).build()
   }
 
-  implicit val doubleValue2Double: Converter[DoubleValue, Double] = Converter(_.getValue)
-  implicit val stringValue2String: Converter[StringValue, String] = Converter(_.getValue)
-  implicit val floatValue2Float: Converter[FloatValue, Float] = Converter(_.getValue)
-  implicit val boolValue2Boolean: Converter[BoolValue, Boolean] = Converter(_.getValue)
-  implicit val int64Value2Long: Converter[Int64Value, Long] = Converter(_.getValue)
-  implicit val int32Value2Int: Converter[Int32Value, Int] = Converter(_.getValue)
-  implicit val bytesValue2ByteString: Converter[BytesValue, ByteString] = Converter(_.getValue)
-  implicit val gpbDuration2Duration: Converter[GpbDuration, Duration] = Converter { v => Duration.ofSeconds(v.getSeconds, v.getNanos) }
-  implicit val gpbTimestamp2Instant: Converter[GpbTimestamp, Instant] = Converter { v => Instant.ofEpochSecond(v.getSeconds, v.getNanos) }
+  implicit val doubleValue2Double: Converter[DoubleValue, Double] = Converter(_ => _.getValue)
+  implicit val stringValue2String: Converter[StringValue, String] = Converter(_ => _.getValue)
+  implicit val floatValue2Float: Converter[FloatValue, Float] = Converter(_ => _.getValue)
+  implicit val boolValue2Boolean: Converter[BoolValue, Boolean] = Converter(_ => _.getValue)
+  implicit val int64Value2Long: Converter[Int64Value, Long] = Converter(_ => _.getValue)
+  implicit val int32Value2Int: Converter[Int32Value, Int] = Converter(_ => _.getValue)
+  implicit val bytesValue2ByteString: Converter[BytesValue, ByteString] = Converter(_ => _.getValue)
+  implicit val gpbDuration2Duration: Converter[GpbDuration, Duration] = Converter { _ => v => Duration.ofSeconds(v.getSeconds, v.getNanos) }
+  implicit val gpbTimestamp2Instant: Converter[GpbTimestamp, Instant] = Converter { _ => v => Instant.ofEpochSecond(v.getSeconds, v.getNanos) }
 
-  implicit val double2DoubleValue: Converter[Double, DoubleValue] = Converter(DoubleValue.newBuilder().setValue(_).build())
-  implicit val string2stringValue: Converter[String, StringValue] = Converter(StringValue.newBuilder().setValue(_).build())
-  implicit val float2floatValue: Converter[Float, FloatValue] = Converter(FloatValue.newBuilder().setValue(_).build())
-  implicit val boolean2boolValue: Converter[Boolean, BoolValue] = Converter(BoolValue.newBuilder().setValue(_).build())
-  implicit val long2int64Value: Converter[Long, Int64Value] = Converter(Int64Value.newBuilder().setValue(_).build())
-  implicit val int2int32Value: Converter[Int, Int32Value] = Converter(Int32Value.newBuilder().setValue(_).build())
-  implicit val byteString2bytesValue: Converter[ByteString, BytesValue] = Converter(BytesValue.newBuilder().setValue(_).build())
-  implicit val duration2gpbDuration: Converter[Duration, GpbDuration] = Converter { d =>
-    GpbDuration.newBuilder().setSeconds(d.getSeconds).setNanos(d.getNano).build()
+  implicit val double2DoubleValue: Converter[Double, DoubleValue] = Converter(_ => DoubleValue.newBuilder().setValue(_).build())
+  implicit val string2stringValue: Converter[String, StringValue] = Converter(_ => StringValue.newBuilder().setValue(_).build())
+  implicit val float2floatValue: Converter[Float, FloatValue] = Converter(_ => FloatValue.newBuilder().setValue(_).build())
+  implicit val boolean2boolValue: Converter[Boolean, BoolValue] = Converter(_ => BoolValue.newBuilder().setValue(_).build())
+  implicit val long2int64Value: Converter[Long, Int64Value] = Converter(_ => Int64Value.newBuilder().setValue(_).build())
+  implicit val int2int32Value: Converter[Int, Int32Value] = Converter(_ => Int32Value.newBuilder().setValue(_).build())
+  implicit val byteString2bytesValue: Converter[ByteString, BytesValue] = Converter(_ => BytesValue.newBuilder().setValue(_).build())
+  implicit val duration2gpbDuration: Converter[Duration, GpbDuration] = Converter { _ =>
+    d =>
+      GpbDuration.newBuilder().setSeconds(d.getSeconds).setNanos(d.getNano).build()
   }
-  implicit val instant2gpbTimestamp: Converter[Instant, GpbTimestamp] = Converter { i =>
-    GpbTimestamp.newBuilder().setSeconds(i.getEpochSecond).setNanos(i.getNano).build()
+  implicit val instant2gpbTimestamp: Converter[Instant, GpbTimestamp] = Converter { _ =>
+    i =>
+      GpbTimestamp.newBuilder().setSeconds(i.getEpochSecond).setNanos(i.getNano).build()
   }
 }

--- a/macros/src/main/scala/com/avast/cactus/v3/V3Converters.scala
+++ b/macros/src/main/scala/com/avast/cactus/v3/V3Converters.scala
@@ -8,49 +8,43 @@ import com.google.protobuf.{Duration => GpbDuration, Timestamp => GpbTimestamp, 
 import scala.collection.JavaConverters._
 
 trait V3Converters {
-  implicit val listValue2SeqConverter: Converter[com.google.protobuf.ListValue, Seq[ValueOneOf]] = Converter { _ =>
-    listValue =>
-      listValue.getValuesList.asScala.map(ValueOneOf.apply)
+  implicit val listValue2SeqConverter: Converter[com.google.protobuf.ListValue, Seq[ValueOneOf]] = Converter { listValue =>
+    listValue.getValuesList.asScala.map(ValueOneOf.apply)
   }
 
-  implicit val seq2ListValueConverter: Converter[Seq[ValueOneOf], com.google.protobuf.ListValue] = Converter { _ =>
-    values =>
-      ListValue.newBuilder().addAllValues(values.map(ValueOneOf.toGpbValue).asJava).build()
+  implicit val seq2ListValueConverter: Converter[Seq[ValueOneOf], com.google.protobuf.ListValue] = Converter { values =>
+    ListValue.newBuilder().addAllValues(values.map(ValueOneOf.toGpbValue).asJava).build()
   }
 
-  implicit val struct2MapConverter: Converter[com.google.protobuf.Struct, Map[String, ValueOneOf]] = Converter { _ =>
-    struct =>
-      struct.getFieldsMap.asScala.mapValues(ValueOneOf.apply).toMap
+  implicit val struct2MapConverter: Converter[com.google.protobuf.Struct, Map[String, ValueOneOf]] = Converter { struct =>
+    struct.getFieldsMap.asScala.mapValues(ValueOneOf.apply).toMap
   }
 
-  implicit val map2StructConverter: Converter[Map[String, ValueOneOf], com.google.protobuf.Struct] = Converter { _ =>
-    m =>
-      Struct.newBuilder().putAllFields(m.mapValues(ValueOneOf.toGpbValue).asJava).build()
+  implicit val map2StructConverter: Converter[Map[String, ValueOneOf], com.google.protobuf.Struct] = Converter { m =>
+    Struct.newBuilder().putAllFields(m.mapValues(ValueOneOf.toGpbValue).asJava).build()
   }
 
-  implicit val doubleValue2Double: Converter[DoubleValue, Double] = Converter(_ => _.getValue)
-  implicit val stringValue2String: Converter[StringValue, String] = Converter(_ => _.getValue)
-  implicit val floatValue2Float: Converter[FloatValue, Float] = Converter(_ => _.getValue)
-  implicit val boolValue2Boolean: Converter[BoolValue, Boolean] = Converter(_ => _.getValue)
-  implicit val int64Value2Long: Converter[Int64Value, Long] = Converter(_ => _.getValue)
-  implicit val int32Value2Int: Converter[Int32Value, Int] = Converter(_ => _.getValue)
-  implicit val bytesValue2ByteString: Converter[BytesValue, ByteString] = Converter(_ => _.getValue)
-  implicit val gpbDuration2Duration: Converter[GpbDuration, Duration] = Converter { _ => v => Duration.ofSeconds(v.getSeconds, v.getNanos) }
-  implicit val gpbTimestamp2Instant: Converter[GpbTimestamp, Instant] = Converter { _ => v => Instant.ofEpochSecond(v.getSeconds, v.getNanos) }
+  implicit val doubleValue2Double: Converter[DoubleValue, Double] = Converter(_.getValue)
+  implicit val stringValue2String: Converter[StringValue, String] = Converter(_.getValue)
+  implicit val floatValue2Float: Converter[FloatValue, Float] = Converter(_.getValue)
+  implicit val boolValue2Boolean: Converter[BoolValue, Boolean] = Converter(_.getValue)
+  implicit val int64Value2Long: Converter[Int64Value, Long] = Converter(_.getValue)
+  implicit val int32Value2Int: Converter[Int32Value, Int] = Converter(_.getValue)
+  implicit val bytesValue2ByteString: Converter[BytesValue, ByteString] = Converter(_.getValue)
+  implicit val gpbDuration2Duration: Converter[GpbDuration, Duration] = Converter { v => Duration.ofSeconds(v.getSeconds, v.getNanos) }
+  implicit val gpbTimestamp2Instant: Converter[GpbTimestamp, Instant] = Converter { v => Instant.ofEpochSecond(v.getSeconds, v.getNanos) }
 
-  implicit val double2DoubleValue: Converter[Double, DoubleValue] = Converter(_ => DoubleValue.newBuilder().setValue(_).build())
-  implicit val string2stringValue: Converter[String, StringValue] = Converter(_ => StringValue.newBuilder().setValue(_).build())
-  implicit val float2floatValue: Converter[Float, FloatValue] = Converter(_ => FloatValue.newBuilder().setValue(_).build())
-  implicit val boolean2boolValue: Converter[Boolean, BoolValue] = Converter(_ => BoolValue.newBuilder().setValue(_).build())
-  implicit val long2int64Value: Converter[Long, Int64Value] = Converter(_ => Int64Value.newBuilder().setValue(_).build())
-  implicit val int2int32Value: Converter[Int, Int32Value] = Converter(_ => Int32Value.newBuilder().setValue(_).build())
-  implicit val byteString2bytesValue: Converter[ByteString, BytesValue] = Converter(_ => BytesValue.newBuilder().setValue(_).build())
-  implicit val duration2gpbDuration: Converter[Duration, GpbDuration] = Converter { _ =>
-    d =>
-      GpbDuration.newBuilder().setSeconds(d.getSeconds).setNanos(d.getNano).build()
+  implicit val double2DoubleValue: Converter[Double, DoubleValue] = Converter(DoubleValue.newBuilder().setValue(_).build())
+  implicit val string2stringValue: Converter[String, StringValue] = Converter(StringValue.newBuilder().setValue(_).build())
+  implicit val float2floatValue: Converter[Float, FloatValue] = Converter(FloatValue.newBuilder().setValue(_).build())
+  implicit val boolean2boolValue: Converter[Boolean, BoolValue] = Converter(BoolValue.newBuilder().setValue(_).build())
+  implicit val long2int64Value: Converter[Long, Int64Value] = Converter(Int64Value.newBuilder().setValue(_).build())
+  implicit val int2int32Value: Converter[Int, Int32Value] = Converter(Int32Value.newBuilder().setValue(_).build())
+  implicit val byteString2bytesValue: Converter[ByteString, BytesValue] = Converter(BytesValue.newBuilder().setValue(_).build())
+  implicit val duration2gpbDuration: Converter[Duration, GpbDuration] = Converter { d =>
+    GpbDuration.newBuilder().setSeconds(d.getSeconds).setNanos(d.getNano).build()
   }
-  implicit val instant2gpbTimestamp: Converter[Instant, GpbTimestamp] = Converter { _ =>
-    i =>
-      GpbTimestamp.newBuilder().setSeconds(i.getEpochSecond).setNanos(i.getNano).build()
+  implicit val instant2gpbTimestamp: Converter[Instant, GpbTimestamp] = Converter { i =>
+    GpbTimestamp.newBuilder().setSeconds(i.getEpochSecond).setNanos(i.getNano).build()
   }
 }

--- a/macros/src/main/scala/com/avast/cactus/v3/ValueOneOf.scala
+++ b/macros/src/main/scala/com/avast/cactus/v3/ValueOneOf.scala
@@ -1,7 +1,9 @@
 package com.avast.cactus.v3
 
-import com.avast.cactus.Converter
+import com.avast.cactus.{CactusFailures, Converter}
 import com.google.protobuf.{Struct, Value, ListValue => GpbListValue, NullValue => GpbNullValue}
+import org.scalactic.{Good, Or}
+import org.scalactic.Accumulation._
 
 import scala.collection.JavaConverters._
 
@@ -9,16 +11,16 @@ trait ValueOneOf
 
 object ValueOneOf {
 
-  private[cactus] def apply(v: Value): ValueOneOf = v.getKindCase match {
-    case Value.KindCase.KIND_NOT_SET => EmptyValue
-    case Value.KindCase.NULL_VALUE => NullValue(v.getNullValue)
-    case Value.KindCase.NUMBER_VALUE => NumberValue(v.getNumberValue)
-    case Value.KindCase.STRING_VALUE => StringValue(v.getStringValue)
-    case Value.KindCase.BOOL_VALUE => BooleanValue(v.getBoolValue)
-    case Value.KindCase.STRUCT_VALUE => StructValue {
-      v.getStructValue.getFieldsMap.asScala.mapValues(ValueOneOf.apply).toMap
-    }
-    case Value.KindCase.LIST_VALUE => ListValue(Converter.listValue2SeqConverter.apply("ONE-OF")(v.getListValue)) // TODO
+  private[cactus] def apply(fieldPath: String, v: Value): ValueOneOf Or CactusFailures = v.getKindCase match {
+    case Value.KindCase.KIND_NOT_SET => Good(EmptyValue)
+    case Value.KindCase.NULL_VALUE => Good(NullValue(v.getNullValue))
+    case Value.KindCase.NUMBER_VALUE => Good(NumberValue(v.getNumberValue))
+    case Value.KindCase.STRING_VALUE => Good(StringValue(v.getStringValue))
+    case Value.KindCase.BOOL_VALUE => Good(BooleanValue(v.getBoolValue))
+    case Value.KindCase.LIST_VALUE => Converter.listValue2SeqConverter(fieldPath)(v.getListValue).map(ListValue)
+    case Value.KindCase.STRUCT_VALUE =>
+      val scalaMap = v.getStructValue.getFieldsMap.asScala
+      scalaMap.map { case (key, value) => ValueOneOf.apply(fieldPath, value).map(key -> _) }.toIterable.combined.map(_.toMap).map(StructValue)
   }
 
   private[cactus] def toGpbValue(vof: ValueOneOf): Value = vof match {

--- a/macros/src/main/scala/com/avast/cactus/v3/ValueOneOf.scala
+++ b/macros/src/main/scala/com/avast/cactus/v3/ValueOneOf.scala
@@ -18,7 +18,7 @@ object ValueOneOf {
     case Value.KindCase.STRUCT_VALUE => StructValue {
       v.getStructValue.getFieldsMap.asScala.mapValues(ValueOneOf.apply).toMap
     }
-    case Value.KindCase.LIST_VALUE => ListValue(Converter.listValue2SeqConverter.apply(v.getListValue))
+    case Value.KindCase.LIST_VALUE => ListValue(Converter.listValue2SeqConverter.apply("ONE-OF")(v.getListValue)) // TODO
   }
 
   private[cactus] def toGpbValue(vof: ValueOneOf): Value = vof match {

--- a/macros/src/test/scala/com/avast/cactus/v2/CactusMacrosTestV2.scala
+++ b/macros/src/test/scala/com/avast/cactus/v2/CactusMacrosTestV2.scala
@@ -100,67 +100,67 @@ class CactusMacrosTestV2 extends FunSuite {
       case Good(_) => fail("Should fail")
     }
   }
-
-  test("Case class to GPB") {
-    val map = Map("first" -> CaseClassMapInnerMessage("str", 1), "second" -> CaseClassMapInnerMessage("str", 2))
-    val map2 = Map("first" -> 1, "second" -> 2)
-
-    val caseClassB = CaseClassB(0.9, "text")
-
-    val caseClassD = Seq(CaseClassD(Seq(caseClassB, caseClassB, caseClassB)))
-
-    val caseClass = CaseClassA("ahoj", 9, Some(13), ByteString.EMPTY, List("a"), caseClassB, Some(caseClassB), None, Seq(caseClassB, caseClassB, caseClassB), caseClassD, List("a", "b"), Vector(3, 6), List(), "1, 2", map, map2)
-
-    val gpbInternal = Data2.newBuilder()
-      .setFieldDouble(0.9)
-      .setFieldBlob(ByteString.copyFromUtf8("text"))
-      .build()
-
-    val dataRepeated = Seq(gpbInternal, gpbInternal, gpbInternal)
-
-    val expectedGpb = TestMessageV2.Data.newBuilder()
-      .setFieldString("ahoj")
-      .setFieldIntName(9)
-      .setFieldOption(13)
-      .setFieldBlob(ByteString.EMPTY)
-      .setFieldGpb(gpbInternal)
-      .setFieldGpbOption(gpbInternal)
-      .addAllFieldGpbRepeated(dataRepeated.asJava)
-      .addFieldGpb2RepeatedRecurse(Data3.newBuilder().addAllFieldGpb(dataRepeated.asJava).build())
-      .addAllFieldStrings(Seq("a", "b").asJava)
-      .addAllFieldStringsName(Seq("a").asJava)
-      .addAllFieldOptionIntegers(Seq(3, 6).map(int2Integer).asJava)
-      .addAllFieldMap(map.map { case (key, value) =>
-        TestMessageV2.MapMessage.newBuilder().setKey(key).setValue(MapInnerMessage.newBuilder().setFieldInt(value.fieldInt).setFieldString(value.fieldString)).build()
-      }.asJava)
-      .addAllFieldMap2(map.map { case (key, value) =>
-        TestMessageV2.MapMessage.newBuilder().setKey(key).setValue(MapInnerMessage.newBuilder().setFieldInt(value.fieldInt).setFieldString(value.fieldString)).build()
-      }.asJava)
-      .addAllFieldIntegers2(Seq(1, 2).map(int2Integer).asJava)
-      .build()
-
-    caseClass.asGpb[Data] match {
-      case Good(e) if e == expectedGpb => // ok
-    }
-  }
-
-  test("convert case class to GPB and back") {
-    val map = Map("first" -> CaseClassMapInnerMessage("str", 1), "second" -> CaseClassMapInnerMessage("str", 2))
-
-    val original = CaseClassC(StringWrapperClass("ahoj"), 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, Array("a", "b"), Vector(3, 6), List(), map)
-
-    val Good(converted) = original.asGpb[Data]
-
-    assertResult(Good(original))(converted.asCaseClass[CaseClassC])
-  }
-
-  test("convert case class with ignored field to GPB and back") {
-    val original = CaseClassE(fieldString = "ahoj", fieldOption = Some("ahoj2"), fieldBytes = Bytes.copyFromUtf8("hello"))
-
-    val Good(converted) = original.asGpb[Data4]
-
-    assertResult(Good(original))(converted.asCaseClass[CaseClassE])
-  }
+//
+//  test("Case class to GPB") {
+//    val map = Map("first" -> CaseClassMapInnerMessage("str", 1), "second" -> CaseClassMapInnerMessage("str", 2))
+//    val map2 = Map("first" -> 1, "second" -> 2)
+//
+//    val caseClassB = CaseClassB(0.9, "text")
+//
+//    val caseClassD = Seq(CaseClassD(Seq(caseClassB, caseClassB, caseClassB)))
+//
+//    val caseClass = CaseClassA("ahoj", 9, Some(13), ByteString.EMPTY, List("a"), caseClassB, Some(caseClassB), None, Seq(caseClassB, caseClassB, caseClassB), caseClassD, List("a", "b"), Vector(3, 6), List(), "1, 2", map, map2)
+//
+//    val gpbInternal = Data2.newBuilder()
+//      .setFieldDouble(0.9)
+//      .setFieldBlob(ByteString.copyFromUtf8("text"))
+//      .build()
+//
+//    val dataRepeated = Seq(gpbInternal, gpbInternal, gpbInternal)
+//
+//    val expectedGpb = TestMessageV2.Data.newBuilder()
+//      .setFieldString("ahoj")
+//      .setFieldIntName(9)
+//      .setFieldOption(13)
+//      .setFieldBlob(ByteString.EMPTY)
+//      .setFieldGpb(gpbInternal)
+//      .setFieldGpbOption(gpbInternal)
+//      .addAllFieldGpbRepeated(dataRepeated.asJava)
+//      .addFieldGpb2RepeatedRecurse(Data3.newBuilder().addAllFieldGpb(dataRepeated.asJava).build())
+//      .addAllFieldStrings(Seq("a", "b").asJava)
+//      .addAllFieldStringsName(Seq("a").asJava)
+//      .addAllFieldOptionIntegers(Seq(3, 6).map(int2Integer).asJava)
+//      .addAllFieldMap(map.map { case (key, value) =>
+//        TestMessageV2.MapMessage.newBuilder().setKey(key).setValue(MapInnerMessage.newBuilder().setFieldInt(value.fieldInt).setFieldString(value.fieldString)).build()
+//      }.asJava)
+//      .addAllFieldMap2(map.map { case (key, value) =>
+//        TestMessageV2.MapMessage.newBuilder().setKey(key).setValue(MapInnerMessage.newBuilder().setFieldInt(value.fieldInt).setFieldString(value.fieldString)).build()
+//      }.asJava)
+//      .addAllFieldIntegers2(Seq(1, 2).map(int2Integer).asJava)
+//      .build()
+//
+//    caseClass.asGpb[Data] match {
+//      case Good(e) if e == expectedGpb => // ok
+//    }
+//  }
+//
+//  test("convert case class to GPB and back") {
+//    val map = Map("first" -> CaseClassMapInnerMessage("str", 1), "second" -> CaseClassMapInnerMessage("str", 2))
+//
+//    val original = CaseClassC(StringWrapperClass("ahoj"), 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, Array("a", "b"), Vector(3, 6), List(), map)
+//
+//    val Good(converted) = original.asGpb[Data]
+//
+//    assertResult(Good(original))(converted.asCaseClass[CaseClassC])
+//  }
+//
+//  test("convert case class with ignored field to GPB and back") {
+//    val original = CaseClassE(fieldString = "ahoj", fieldOption = Some("ahoj2"), fieldBytes = Bytes.copyFromUtf8("hello"))
+//
+//    val Good(converted) = original.asGpb[Data4]
+//
+//    assertResult(Good(original))(converted.asCaseClass[CaseClassE])
+//  }
 }
 
 case class CaseClassA(fieldString: String,

--- a/macros/src/test/scala/com/avast/cactus/v2/CactusMacrosTestV2.scala
+++ b/macros/src/test/scala/com/avast/cactus/v2/CactusMacrosTestV2.scala
@@ -100,67 +100,67 @@ class CactusMacrosTestV2 extends FunSuite {
       case Good(_) => fail("Should fail")
     }
   }
-//
-//  test("Case class to GPB") {
-//    val map = Map("first" -> CaseClassMapInnerMessage("str", 1), "second" -> CaseClassMapInnerMessage("str", 2))
-//    val map2 = Map("first" -> 1, "second" -> 2)
-//
-//    val caseClassB = CaseClassB(0.9, "text")
-//
-//    val caseClassD = Seq(CaseClassD(Seq(caseClassB, caseClassB, caseClassB)))
-//
-//    val caseClass = CaseClassA("ahoj", 9, Some(13), ByteString.EMPTY, List("a"), caseClassB, Some(caseClassB), None, Seq(caseClassB, caseClassB, caseClassB), caseClassD, List("a", "b"), Vector(3, 6), List(), "1, 2", map, map2)
-//
-//    val gpbInternal = Data2.newBuilder()
-//      .setFieldDouble(0.9)
-//      .setFieldBlob(ByteString.copyFromUtf8("text"))
-//      .build()
-//
-//    val dataRepeated = Seq(gpbInternal, gpbInternal, gpbInternal)
-//
-//    val expectedGpb = TestMessageV2.Data.newBuilder()
-//      .setFieldString("ahoj")
-//      .setFieldIntName(9)
-//      .setFieldOption(13)
-//      .setFieldBlob(ByteString.EMPTY)
-//      .setFieldGpb(gpbInternal)
-//      .setFieldGpbOption(gpbInternal)
-//      .addAllFieldGpbRepeated(dataRepeated.asJava)
-//      .addFieldGpb2RepeatedRecurse(Data3.newBuilder().addAllFieldGpb(dataRepeated.asJava).build())
-//      .addAllFieldStrings(Seq("a", "b").asJava)
-//      .addAllFieldStringsName(Seq("a").asJava)
-//      .addAllFieldOptionIntegers(Seq(3, 6).map(int2Integer).asJava)
-//      .addAllFieldMap(map.map { case (key, value) =>
-//        TestMessageV2.MapMessage.newBuilder().setKey(key).setValue(MapInnerMessage.newBuilder().setFieldInt(value.fieldInt).setFieldString(value.fieldString)).build()
-//      }.asJava)
-//      .addAllFieldMap2(map.map { case (key, value) =>
-//        TestMessageV2.MapMessage.newBuilder().setKey(key).setValue(MapInnerMessage.newBuilder().setFieldInt(value.fieldInt).setFieldString(value.fieldString)).build()
-//      }.asJava)
-//      .addAllFieldIntegers2(Seq(1, 2).map(int2Integer).asJava)
-//      .build()
-//
-//    caseClass.asGpb[Data] match {
-//      case Good(e) if e == expectedGpb => // ok
-//    }
-//  }
-//
-//  test("convert case class to GPB and back") {
-//    val map = Map("first" -> CaseClassMapInnerMessage("str", 1), "second" -> CaseClassMapInnerMessage("str", 2))
-//
-//    val original = CaseClassC(StringWrapperClass("ahoj"), 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, Array("a", "b"), Vector(3, 6), List(), map)
-//
-//    val Good(converted) = original.asGpb[Data]
-//
-//    assertResult(Good(original))(converted.asCaseClass[CaseClassC])
-//  }
-//
-//  test("convert case class with ignored field to GPB and back") {
-//    val original = CaseClassE(fieldString = "ahoj", fieldOption = Some("ahoj2"), fieldBytes = Bytes.copyFromUtf8("hello"))
-//
-//    val Good(converted) = original.asGpb[Data4]
-//
-//    assertResult(Good(original))(converted.asCaseClass[CaseClassE])
-//  }
+
+  test("Case class to GPB") {
+    val map = Map("first" -> CaseClassMapInnerMessage("str", 1), "second" -> CaseClassMapInnerMessage("str", 2))
+    val map2 = Map("first" -> 1, "second" -> 2)
+
+    val caseClassB = CaseClassB(0.9, "text")
+
+    val caseClassD = Seq(CaseClassD(Seq(caseClassB, caseClassB, caseClassB)))
+
+    val caseClass = CaseClassA("ahoj", 9, Some(13), ByteString.EMPTY, List("a"), caseClassB, Some(caseClassB), None, Seq(caseClassB, caseClassB, caseClassB), caseClassD, List("a", "b"), Vector(3, 6), List(), "1, 2", map, map2)
+
+    val gpbInternal = Data2.newBuilder()
+      .setFieldDouble(0.9)
+      .setFieldBlob(ByteString.copyFromUtf8("text"))
+      .build()
+
+    val dataRepeated = Seq(gpbInternal, gpbInternal, gpbInternal)
+
+    val expectedGpb = TestMessageV2.Data.newBuilder()
+      .setFieldString("ahoj")
+      .setFieldIntName(9)
+      .setFieldOption(13)
+      .setFieldBlob(ByteString.EMPTY)
+      .setFieldGpb(gpbInternal)
+      .setFieldGpbOption(gpbInternal)
+      .addAllFieldGpbRepeated(dataRepeated.asJava)
+      .addFieldGpb2RepeatedRecurse(Data3.newBuilder().addAllFieldGpb(dataRepeated.asJava).build())
+      .addAllFieldStrings(Seq("a", "b").asJava)
+      .addAllFieldStringsName(Seq("a").asJava)
+      .addAllFieldOptionIntegers(Seq(3, 6).map(int2Integer).asJava)
+      .addAllFieldMap(map.map { case (key, value) =>
+        TestMessageV2.MapMessage.newBuilder().setKey(key).setValue(MapInnerMessage.newBuilder().setFieldInt(value.fieldInt).setFieldString(value.fieldString)).build()
+      }.asJava)
+      .addAllFieldMap2(map.map { case (key, value) =>
+        TestMessageV2.MapMessage.newBuilder().setKey(key).setValue(MapInnerMessage.newBuilder().setFieldInt(value.fieldInt).setFieldString(value.fieldString)).build()
+      }.asJava)
+      .addAllFieldIntegers2(Seq(1, 2).map(int2Integer).asJava)
+      .build()
+
+    caseClass.asGpb[Data] match {
+      case Good(e) if e == expectedGpb => // ok
+    }
+  }
+
+  test("convert case class to GPB and back") {
+    val map = Map("first" -> CaseClassMapInnerMessage("str", 1), "second" -> CaseClassMapInnerMessage("str", 2))
+
+    val original = CaseClassC(StringWrapperClass("ahoj"), 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, Array("a", "b"), Vector(3, 6), List(), map)
+
+    val Good(converted) = original.asGpb[Data]
+
+    assertResult(Good(original))(converted.asCaseClass[CaseClassC])
+  }
+
+  test("convert case class with ignored field to GPB and back") {
+    val original = CaseClassE(fieldString = "ahoj", fieldOption = Some("ahoj2"), fieldBytes = Bytes.copyFromUtf8("hello"))
+
+    val Good(converted) = original.asGpb[Data4]
+
+    assertResult(Good(original))(converted.asCaseClass[CaseClassE])
+  }
 }
 
 case class CaseClassA(fieldString: String,

--- a/macros/src/test/scala/com/avast/cactus/v2/CactusMacrosTestV2.scala
+++ b/macros/src/test/scala/com/avast/cactus/v2/CactusMacrosTestV2.scala
@@ -14,21 +14,21 @@ import scala.collection.immutable
 class CactusMacrosTestV2 extends FunSuite {
 
   // user specified converters
-  implicit val StringToByteStringConverter: Converter[String, ByteString] = Converter(_ =>(b: String) => ByteString.copyFromUtf8(b))
-  implicit val ByteStringToStringConverter: Converter[ByteString, String] = Converter(_ =>(b: ByteString) => b.toStringUtf8)
+  implicit val StringToByteStringConverter: Converter[String, ByteString] = Converter((b: String) => ByteString.copyFromUtf8(b))
+  implicit val ByteStringToStringConverter: Converter[ByteString, String] = Converter((b: ByteString) => b.toStringUtf8)
 
-  implicit val StringWrapperToStringConverter: Converter[StringWrapperClass, String] = Converter(_ =>(b: StringWrapperClass) => b.value)
-  implicit val StringToStringWrapperConverter: Converter[String, StringWrapperClass] = Converter(_ =>(b: String) => StringWrapperClass(b))
+  implicit val StringWrapperToStringConverter: Converter[StringWrapperClass, String] = Converter((b: StringWrapperClass) => b.value)
+  implicit val StringToStringWrapperConverter: Converter[String, StringWrapperClass] = Converter((b: String) => StringWrapperClass(b))
 
-  implicit val JavaIntegerListStringConverter: Converter[java.util.List[Integer], String] = Converter(_ =>_.asScala.mkString(", "))
-  implicit val StringJavaIntegerListConverter: Converter[String, java.lang.Iterable[_ <: Integer]] = Converter(_ =>_.split(", ").map(_.toInt).map(int2Integer).toSeq.asJava)
+  implicit val JavaIntegerListStringConverter: Converter[java.util.List[Integer], String] = Converter(_.asScala.mkString(", "))
+  implicit val StringJavaIntegerListConverter: Converter[String, java.lang.Iterable[_ <: Integer]] = Converter(_.split(", ").map(_.toInt).map(int2Integer).toSeq.asJava)
 
-  implicit val MapInnerMessageIntConverter: Converter[MapInnerMessage, Int] = Converter(_ =>_.getFieldInt)
-  implicit val IntMapInnerMessageConverter: Converter[Int, MapInnerMessage] = Converter(_ =>MapInnerMessage.newBuilder().setFieldString("str").setFieldInt(_).build())
+  implicit val MapInnerMessageIntConverter: Converter[MapInnerMessage, Int] = Converter(_.getFieldInt)
+  implicit val IntMapInnerMessageConverter: Converter[Int, MapInnerMessage] = Converter(MapInnerMessage.newBuilder().setFieldString("str").setFieldInt(_).build())
 
   // these are not needed, but they are here to be sure it won't cause trouble to the user
-  implicit val ByteArrayToByteStringConverter: Converter[Array[Byte], ByteString] = Converter(_ =>(b: Array[Byte]) => ByteString.copyFrom(b))
-  implicit val ByteStringToByteArrayConverter: Converter[ByteString, Array[Byte]] = Converter(_ =>(b: ByteString) => b.toByteArray)
+  implicit val ByteArrayToByteStringConverter: Converter[Array[Byte], ByteString] = Converter((b: Array[Byte]) => ByteString.copyFrom(b))
+  implicit val ByteStringToByteArrayConverter: Converter[ByteString, Array[Byte]] = Converter((b: ByteString) => b.toByteArray)
 
   test("GPB to case class") {
     val gpbInternal = Data2.newBuilder()

--- a/macros/src/test/scala/com/avast/cactus/v3/CactusMacrosTestV3.scala
+++ b/macros/src/test/scala/com/avast/cactus/v3/CactusMacrosTestV3.scala
@@ -101,165 +101,165 @@ class CactusMacrosTestV3 extends FunSuite {
     }
   }
 
-  test("Case class to GPB") {
-    val map = Map("first" -> "1", "second" -> "2")
-    val map2 = Map("first" -> 1, "second" -> 2)
-
-    val caseClassB = CaseClassB(0.9, "text")
-
-    val caseClassD = Seq(CaseClassD(Seq(caseClassB, caseClassB, caseClassB), OneOfNamed2.FooInt(9)))
-    val caseClassF = CaseClassF(Seq(caseClassB, caseClassB, caseClassB), None)
-
-    val caseClass = CaseClassA("ahoj", 9, Some(13), ByteString.EMPTY, List("a"), caseClassB, caseClassB, caseClassF, Some(caseClassB), None, Seq(caseClassB, caseClassB, caseClassB), caseClassD, List("a", "b"), Vector(3, 6), List(), "1, 2", map, map2)
-
-    val gpbInternal = Data2.newBuilder()
-      .setFieldDouble(0.9)
-      .setFieldBlob(ByteString.copyFromUtf8("text"))
-      .build()
-
-    val dataRepeated = Seq(gpbInternal, gpbInternal, gpbInternal)
-
-    val expectedGpb = TestMessageV3.Data.newBuilder()
-      .setFieldString("ahoj")
-      .setFieldIntName(9)
-      .setFieldOption(13)
-      .setFieldBlob(ByteString.EMPTY)
-      .setFieldGpb(gpbInternal)
-      .setFieldGpb2(gpbInternal)
-      .setFieldGpb3(Data5.newBuilder().addAllFieldGpb(dataRepeated.asJava).build())
-      .setFieldGpbOption(gpbInternal)
-      .addAllFieldGpbRepeated(dataRepeated.asJava)
-      .addFieldGpb2RepeatedRecurse(Data3.newBuilder().addAllFieldGpb(dataRepeated.asJava).setFooInt(9).build())
-      .addAllFieldStrings(Seq("a", "b").asJava)
-      .addAllFieldStringsName(Seq("a").asJava)
-      .addAllFieldOptionIntegers(Seq(3, 6).map(int2Integer).asJava)
-      .addAllFieldMap(map.map { case (key, value) => TestMessageV3.MapMessage.newBuilder().setKey(key).setValue(value).build() }.asJava)
-      .addAllFieldMap2(map2.map { case (key, value) => TestMessageV3.MapMessage.newBuilder().setKey(key).setValue(value.toString).build() }.asJava)
-      .addAllFieldIntegers2(Seq(1, 2).map(int2Integer).asJava)
-      .build()
-
-    caseClass.asGpb[Data] match {
-      case Good(e) if e == expectedGpb => // ok
-    }
-  }
-
-  test("convert case class to GPB and back") {
-    val map = Map("first" -> "1", "second" -> "2")
-
-    val original = CaseClassC(StringWrapperClass("ahoj"), 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, Array("a", "b"), Vector(3, 6), List(), map)
-
-    val Good(converted) = original.asGpb[Data]
-
-    assertResult(Good(original))(converted.asCaseClass[CaseClassC])
-  }
-
-  test("convert case class with ignored field to GPB and back") {
-    val original = CaseClassE(fieldString = "ahoj", fieldOption = Some("ahoj2"))
-
-    val Good(converted) = original.asGpb[Data4]
-
-    assertResult(Good(original))(converted.asCaseClass[CaseClassE])
-  }
-
-  test("gpb3 map to GPB and back") {
-    val original = CaseClassG(fieldString = "ahoj",
-      fieldOption = Some("ahoj2"),
-      fieldMap = Map("one" -> 1, "two" -> 2),
-      fieldMap2 = Map("one" -> CaseClassMapInnerMessage("str", 42))
-    )
-
-    val Good(converted) = original.asGpb[Data4]
-
-    assertResult(Good(original))(converted.asCaseClass[CaseClassG])
-  }
-
-  test("extensions from GPB and back") {
-    val gpb = ExtensionsMessage.newBuilder()
-      .setBoolValue(BoolValue.newBuilder().setValue(true))
-      .setInt32Value(Int32Value.newBuilder().setValue(123))
-      .setInt64Value(Int64Value.newBuilder().setValue(456))
-      .setFloatValue(FloatValue.newBuilder().setValue(123.456f))
-      .setBytesValue(BytesValue.newBuilder().setValue(ByteString.copyFromUtf8("+ěščřžýáíé")))
-      .setDuration(GpbDuration.newBuilder().setSeconds(123).setNanos(456))
-      .setTimestamp(GpbTimestamp.newBuilder().setSeconds(123).setNanos(456))
-      .setListValue(ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(456.789)))
-      .setListValue2(ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(456.789)))
-      .setListValue3(ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(456.789)))
-      .setStruct(Struct.newBuilder().putFields("mapKey", Value.newBuilder().setNumberValue(42).build()))
-      .build()
-
-    val expected = CaseClassExtensions(
-      boolValue = BoolValue.newBuilder().setValue(true).build(),
-      int32Value = Int32Value.newBuilder().setValue(123).build(),
-      longValue = Int64Value.newBuilder().setValue(456).build(),
-      floatValue = Some(FloatValue.newBuilder().setValue(123.456f).build()),
-      doubleValue = None,
-      stringValue = None,
-      bytesValue = BytesValue.newBuilder().setValue(ByteString.copyFromUtf8("+ěščřžýáíé")).build(),
-      duration = GpbDuration.newBuilder().setSeconds(123).setNanos(456).build(),
-      timestamp = GpbTimestamp.newBuilder().setSeconds(123).setNanos(456).build(),
-      listValue = ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(456.789)).build(),
-      listValue2 = Seq(NumberValue(456.789)),
-      listValue3 = Some(Seq(NumberValue(456.789))),
-      listValue4 = None,
-      struct = Map("mapKey" -> NumberValue(42))
-    )
-
-    val Good(converted) = gpb.asCaseClass[CaseClassExtensions]
-
-    assertResult(expected)(converted)
-
-    assertResult(Good(gpb))(converted.asGpb[ExtensionsMessage])
-  }
-
-  test("extensions from GPB and back - scala types") {
-    val gpb = ExtensionsMessage.newBuilder()
-      .setBoolValue(BoolValue.newBuilder().setValue(true))
-      .setInt32Value(Int32Value.newBuilder().setValue(123))
-      .setInt64Value(Int64Value.newBuilder().setValue(456))
-      .setFloatValue(FloatValue.newBuilder().setValue(123.456f))
-      .setBytesValue(BytesValue.newBuilder().setValue(ByteString.copyFromUtf8("+ěščřžýáíé")))
-      .setDuration(GpbDuration.newBuilder().setSeconds(123).setNanos(456))
-      .setTimestamp(GpbTimestamp.newBuilder().setSeconds(123).setNanos(456))
-      .setListValue(ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(456.789)))
-      .build()
-
-    val expected = CaseClassExtensionsScala(
-      boolValue = true,
-      int32Value = 123,
-      longValue = 456,
-      floatValue = Some(123.456f),
-      doubleValue = None,
-      stringValue = None,
-      bytesValue = ByteString.copyFromUtf8("+ěščřžýáíé"),
-      duration = Duration.ofSeconds(123, 456),
-      timestamp = Instant.ofEpochSecond(123, 456),
-      listValue = Seq(NumberValue(456.789))
-    )
-
-    val Good(converted) = gpb.asCaseClass[CaseClassExtensionsScala]
-
-    assertResult(expected)(converted)
-
-    assertResult(Good(gpb))(converted.asGpb[ExtensionsMessage])
-  }
-
-  test("any extension to GPB and back") {
-    val innerMessage = MessageInsideAnyField.newBuilder().setFieldInt(42).setFieldString("ahoj").build()
-
-    val orig = ExtClass(Instant.ofEpochSecond(12345), AnyValue.of(innerMessage))
-
-    val expected = ExtensionsMessage.newBuilder().setTimestamp(GpbTimestamp.newBuilder().setSeconds(12345)).setAny(Any.pack(innerMessage)).build()
-
-    val Good(converted) = orig.asGpb[ExtensionsMessage]
-
-    assertResult(expected)(converted)
-
-    val actual = converted.asCaseClass[ExtClass]
-
-    assertResult(Good(orig))(actual)
-    assertResult(Good(innerMessage))(actual.flatMap(_.any.asGpb[MessageInsideAnyField]))
-  }
+//  test("Case class to GPB") {
+//    val map = Map("first" -> "1", "second" -> "2")
+//    val map2 = Map("first" -> 1, "second" -> 2)
+//
+//    val caseClassB = CaseClassB(0.9, "text")
+//
+//    val caseClassD = Seq(CaseClassD(Seq(caseClassB, caseClassB, caseClassB), OneOfNamed2.FooInt(9)))
+//    val caseClassF = CaseClassF(Seq(caseClassB, caseClassB, caseClassB), None)
+//
+//    val caseClass = CaseClassA("ahoj", 9, Some(13), ByteString.EMPTY, List("a"), caseClassB, caseClassB, caseClassF, Some(caseClassB), None, Seq(caseClassB, caseClassB, caseClassB), caseClassD, List("a", "b"), Vector(3, 6), List(), "1, 2", map, map2)
+//
+//    val gpbInternal = Data2.newBuilder()
+//      .setFieldDouble(0.9)
+//      .setFieldBlob(ByteString.copyFromUtf8("text"))
+//      .build()
+//
+//    val dataRepeated = Seq(gpbInternal, gpbInternal, gpbInternal)
+//
+//    val expectedGpb = TestMessageV3.Data.newBuilder()
+//      .setFieldString("ahoj")
+//      .setFieldIntName(9)
+//      .setFieldOption(13)
+//      .setFieldBlob(ByteString.EMPTY)
+//      .setFieldGpb(gpbInternal)
+//      .setFieldGpb2(gpbInternal)
+//      .setFieldGpb3(Data5.newBuilder().addAllFieldGpb(dataRepeated.asJava).build())
+//      .setFieldGpbOption(gpbInternal)
+//      .addAllFieldGpbRepeated(dataRepeated.asJava)
+//      .addFieldGpb2RepeatedRecurse(Data3.newBuilder().addAllFieldGpb(dataRepeated.asJava).setFooInt(9).build())
+//      .addAllFieldStrings(Seq("a", "b").asJava)
+//      .addAllFieldStringsName(Seq("a").asJava)
+//      .addAllFieldOptionIntegers(Seq(3, 6).map(int2Integer).asJava)
+//      .addAllFieldMap(map.map { case (key, value) => TestMessageV3.MapMessage.newBuilder().setKey(key).setValue(value).build() }.asJava)
+//      .addAllFieldMap2(map2.map { case (key, value) => TestMessageV3.MapMessage.newBuilder().setKey(key).setValue(value.toString).build() }.asJava)
+//      .addAllFieldIntegers2(Seq(1, 2).map(int2Integer).asJava)
+//      .build()
+//
+//    caseClass.asGpb[Data] match {
+//      case Good(e) if e == expectedGpb => // ok
+//    }
+//  }
+//
+//  test("convert case class to GPB and back") {
+//    val map = Map("first" -> "1", "second" -> "2")
+//
+//    val original = CaseClassC(StringWrapperClass("ahoj"), 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, Array("a", "b"), Vector(3, 6), List(), map)
+//
+//    val Good(converted) = original.asGpb[Data]
+//
+//    assertResult(Good(original))(converted.asCaseClass[CaseClassC])
+//  }
+//
+//  test("convert case class with ignored field to GPB and back") {
+//    val original = CaseClassE(fieldString = "ahoj", fieldOption = Some("ahoj2"))
+//
+//    val Good(converted) = original.asGpb[Data4]
+//
+//    assertResult(Good(original))(converted.asCaseClass[CaseClassE])
+//  }
+//
+//  test("gpb3 map to GPB and back") {
+//    val original = CaseClassG(fieldString = "ahoj",
+//      fieldOption = Some("ahoj2"),
+//      fieldMap = Map("one" -> 1, "two" -> 2),
+//      fieldMap2 = Map("one" -> CaseClassMapInnerMessage("str", 42))
+//    )
+//
+//    val Good(converted) = original.asGpb[Data4]
+//
+//    assertResult(Good(original))(converted.asCaseClass[CaseClassG])
+//  }
+//
+//  test("extensions from GPB and back") {
+//    val gpb = ExtensionsMessage.newBuilder()
+//      .setBoolValue(BoolValue.newBuilder().setValue(true))
+//      .setInt32Value(Int32Value.newBuilder().setValue(123))
+//      .setInt64Value(Int64Value.newBuilder().setValue(456))
+//      .setFloatValue(FloatValue.newBuilder().setValue(123.456f))
+//      .setBytesValue(BytesValue.newBuilder().setValue(ByteString.copyFromUtf8("+ěščřžýáíé")))
+//      .setDuration(GpbDuration.newBuilder().setSeconds(123).setNanos(456))
+//      .setTimestamp(GpbTimestamp.newBuilder().setSeconds(123).setNanos(456))
+//      .setListValue(ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(456.789)))
+//      .setListValue2(ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(456.789)))
+//      .setListValue3(ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(456.789)))
+//      .setStruct(Struct.newBuilder().putFields("mapKey", Value.newBuilder().setNumberValue(42).build()))
+//      .build()
+//
+//    val expected = CaseClassExtensions(
+//      boolValue = BoolValue.newBuilder().setValue(true).build(),
+//      int32Value = Int32Value.newBuilder().setValue(123).build(),
+//      longValue = Int64Value.newBuilder().setValue(456).build(),
+//      floatValue = Some(FloatValue.newBuilder().setValue(123.456f).build()),
+//      doubleValue = None,
+//      stringValue = None,
+//      bytesValue = BytesValue.newBuilder().setValue(ByteString.copyFromUtf8("+ěščřžýáíé")).build(),
+//      duration = GpbDuration.newBuilder().setSeconds(123).setNanos(456).build(),
+//      timestamp = GpbTimestamp.newBuilder().setSeconds(123).setNanos(456).build(),
+//      listValue = ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(456.789)).build(),
+//      listValue2 = Seq(NumberValue(456.789)),
+//      listValue3 = Some(Seq(NumberValue(456.789))),
+//      listValue4 = None,
+//      struct = Map("mapKey" -> NumberValue(42))
+//    )
+//
+//    val Good(converted) = gpb.asCaseClass[CaseClassExtensions]
+//
+//    assertResult(expected)(converted)
+//
+//    assertResult(Good(gpb))(converted.asGpb[ExtensionsMessage])
+//  }
+//
+//  test("extensions from GPB and back - scala types") {
+//    val gpb = ExtensionsMessage.newBuilder()
+//      .setBoolValue(BoolValue.newBuilder().setValue(true))
+//      .setInt32Value(Int32Value.newBuilder().setValue(123))
+//      .setInt64Value(Int64Value.newBuilder().setValue(456))
+//      .setFloatValue(FloatValue.newBuilder().setValue(123.456f))
+//      .setBytesValue(BytesValue.newBuilder().setValue(ByteString.copyFromUtf8("+ěščřžýáíé")))
+//      .setDuration(GpbDuration.newBuilder().setSeconds(123).setNanos(456))
+//      .setTimestamp(GpbTimestamp.newBuilder().setSeconds(123).setNanos(456))
+//      .setListValue(ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(456.789)))
+//      .build()
+//
+//    val expected = CaseClassExtensionsScala(
+//      boolValue = true,
+//      int32Value = 123,
+//      longValue = 456,
+//      floatValue = Some(123.456f),
+//      doubleValue = None,
+//      stringValue = None,
+//      bytesValue = ByteString.copyFromUtf8("+ěščřžýáíé"),
+//      duration = Duration.ofSeconds(123, 456),
+//      timestamp = Instant.ofEpochSecond(123, 456),
+//      listValue = Seq(NumberValue(456.789))
+//    )
+//
+//    val Good(converted) = gpb.asCaseClass[CaseClassExtensionsScala]
+//
+//    assertResult(expected)(converted)
+//
+//    assertResult(Good(gpb))(converted.asGpb[ExtensionsMessage])
+//  }
+//
+//  test("any extension to GPB and back") {
+//    val innerMessage = MessageInsideAnyField.newBuilder().setFieldInt(42).setFieldString("ahoj").build()
+//
+//    val orig = ExtClass(Instant.ofEpochSecond(12345), AnyValue.of(innerMessage))
+//
+//    val expected = ExtensionsMessage.newBuilder().setTimestamp(GpbTimestamp.newBuilder().setSeconds(12345)).setAny(Any.pack(innerMessage)).build()
+//
+//    val Good(converted) = orig.asGpb[ExtensionsMessage]
+//
+//    assertResult(expected)(converted)
+//
+//    val actual = converted.asCaseClass[ExtClass]
+//
+//    assertResult(Good(orig))(actual)
+//    assertResult(Good(innerMessage))(actual.flatMap(_.any.asGpb[MessageInsideAnyField]))
+//  }
 }
 
 case class CaseClassA(fieldString: String,

--- a/macros/src/test/scala/com/avast/cactus/v3/CactusMacrosTestV3.scala
+++ b/macros/src/test/scala/com/avast/cactus/v3/CactusMacrosTestV3.scala
@@ -91,7 +91,7 @@ class CactusMacrosTestV3 extends FunSuite {
       .setFieldGpb3(Data5.newBuilder().build())
       .build()
 
-    val expected = List("fieldGpb", "fieldGpb2").map(MissingFieldFailure).sortBy(_.toString) :+ OneOfValueNotSetFailure("NamedOneOf")
+    val expected = List("gpb.fieldGpb", "gpb.fieldGpb2").map(MissingFieldFailure).sortBy(_.toString) :+ OneOfValueNotSetFailure("gpb.fieldGpb2RepeatedRecurse.NamedOneOf")
 
     gpb.asCaseClass[CaseClassA] match {
       case Bad(e) =>

--- a/macros/src/test/scala/com/avast/cactus/v3/CactusMacrosTestV3.scala
+++ b/macros/src/test/scala/com/avast/cactus/v3/CactusMacrosTestV3.scala
@@ -101,165 +101,165 @@ class CactusMacrosTestV3 extends FunSuite {
     }
   }
 
-//  test("Case class to GPB") {
-//    val map = Map("first" -> "1", "second" -> "2")
-//    val map2 = Map("first" -> 1, "second" -> 2)
-//
-//    val caseClassB = CaseClassB(0.9, "text")
-//
-//    val caseClassD = Seq(CaseClassD(Seq(caseClassB, caseClassB, caseClassB), OneOfNamed2.FooInt(9)))
-//    val caseClassF = CaseClassF(Seq(caseClassB, caseClassB, caseClassB), None)
-//
-//    val caseClass = CaseClassA("ahoj", 9, Some(13), ByteString.EMPTY, List("a"), caseClassB, caseClassB, caseClassF, Some(caseClassB), None, Seq(caseClassB, caseClassB, caseClassB), caseClassD, List("a", "b"), Vector(3, 6), List(), "1, 2", map, map2)
-//
-//    val gpbInternal = Data2.newBuilder()
-//      .setFieldDouble(0.9)
-//      .setFieldBlob(ByteString.copyFromUtf8("text"))
-//      .build()
-//
-//    val dataRepeated = Seq(gpbInternal, gpbInternal, gpbInternal)
-//
-//    val expectedGpb = TestMessageV3.Data.newBuilder()
-//      .setFieldString("ahoj")
-//      .setFieldIntName(9)
-//      .setFieldOption(13)
-//      .setFieldBlob(ByteString.EMPTY)
-//      .setFieldGpb(gpbInternal)
-//      .setFieldGpb2(gpbInternal)
-//      .setFieldGpb3(Data5.newBuilder().addAllFieldGpb(dataRepeated.asJava).build())
-//      .setFieldGpbOption(gpbInternal)
-//      .addAllFieldGpbRepeated(dataRepeated.asJava)
-//      .addFieldGpb2RepeatedRecurse(Data3.newBuilder().addAllFieldGpb(dataRepeated.asJava).setFooInt(9).build())
-//      .addAllFieldStrings(Seq("a", "b").asJava)
-//      .addAllFieldStringsName(Seq("a").asJava)
-//      .addAllFieldOptionIntegers(Seq(3, 6).map(int2Integer).asJava)
-//      .addAllFieldMap(map.map { case (key, value) => TestMessageV3.MapMessage.newBuilder().setKey(key).setValue(value).build() }.asJava)
-//      .addAllFieldMap2(map2.map { case (key, value) => TestMessageV3.MapMessage.newBuilder().setKey(key).setValue(value.toString).build() }.asJava)
-//      .addAllFieldIntegers2(Seq(1, 2).map(int2Integer).asJava)
-//      .build()
-//
-//    caseClass.asGpb[Data] match {
-//      case Good(e) if e == expectedGpb => // ok
-//    }
-//  }
-//
-//  test("convert case class to GPB and back") {
-//    val map = Map("first" -> "1", "second" -> "2")
-//
-//    val original = CaseClassC(StringWrapperClass("ahoj"), 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, Array("a", "b"), Vector(3, 6), List(), map)
-//
-//    val Good(converted) = original.asGpb[Data]
-//
-//    assertResult(Good(original))(converted.asCaseClass[CaseClassC])
-//  }
-//
-//  test("convert case class with ignored field to GPB and back") {
-//    val original = CaseClassE(fieldString = "ahoj", fieldOption = Some("ahoj2"))
-//
-//    val Good(converted) = original.asGpb[Data4]
-//
-//    assertResult(Good(original))(converted.asCaseClass[CaseClassE])
-//  }
-//
-//  test("gpb3 map to GPB and back") {
-//    val original = CaseClassG(fieldString = "ahoj",
-//      fieldOption = Some("ahoj2"),
-//      fieldMap = Map("one" -> 1, "two" -> 2),
-//      fieldMap2 = Map("one" -> CaseClassMapInnerMessage("str", 42))
-//    )
-//
-//    val Good(converted) = original.asGpb[Data4]
-//
-//    assertResult(Good(original))(converted.asCaseClass[CaseClassG])
-//  }
-//
-//  test("extensions from GPB and back") {
-//    val gpb = ExtensionsMessage.newBuilder()
-//      .setBoolValue(BoolValue.newBuilder().setValue(true))
-//      .setInt32Value(Int32Value.newBuilder().setValue(123))
-//      .setInt64Value(Int64Value.newBuilder().setValue(456))
-//      .setFloatValue(FloatValue.newBuilder().setValue(123.456f))
-//      .setBytesValue(BytesValue.newBuilder().setValue(ByteString.copyFromUtf8("+ěščřžýáíé")))
-//      .setDuration(GpbDuration.newBuilder().setSeconds(123).setNanos(456))
-//      .setTimestamp(GpbTimestamp.newBuilder().setSeconds(123).setNanos(456))
-//      .setListValue(ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(456.789)))
-//      .setListValue2(ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(456.789)))
-//      .setListValue3(ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(456.789)))
-//      .setStruct(Struct.newBuilder().putFields("mapKey", Value.newBuilder().setNumberValue(42).build()))
-//      .build()
-//
-//    val expected = CaseClassExtensions(
-//      boolValue = BoolValue.newBuilder().setValue(true).build(),
-//      int32Value = Int32Value.newBuilder().setValue(123).build(),
-//      longValue = Int64Value.newBuilder().setValue(456).build(),
-//      floatValue = Some(FloatValue.newBuilder().setValue(123.456f).build()),
-//      doubleValue = None,
-//      stringValue = None,
-//      bytesValue = BytesValue.newBuilder().setValue(ByteString.copyFromUtf8("+ěščřžýáíé")).build(),
-//      duration = GpbDuration.newBuilder().setSeconds(123).setNanos(456).build(),
-//      timestamp = GpbTimestamp.newBuilder().setSeconds(123).setNanos(456).build(),
-//      listValue = ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(456.789)).build(),
-//      listValue2 = Seq(NumberValue(456.789)),
-//      listValue3 = Some(Seq(NumberValue(456.789))),
-//      listValue4 = None,
-//      struct = Map("mapKey" -> NumberValue(42))
-//    )
-//
-//    val Good(converted) = gpb.asCaseClass[CaseClassExtensions]
-//
-//    assertResult(expected)(converted)
-//
-//    assertResult(Good(gpb))(converted.asGpb[ExtensionsMessage])
-//  }
-//
-//  test("extensions from GPB and back - scala types") {
-//    val gpb = ExtensionsMessage.newBuilder()
-//      .setBoolValue(BoolValue.newBuilder().setValue(true))
-//      .setInt32Value(Int32Value.newBuilder().setValue(123))
-//      .setInt64Value(Int64Value.newBuilder().setValue(456))
-//      .setFloatValue(FloatValue.newBuilder().setValue(123.456f))
-//      .setBytesValue(BytesValue.newBuilder().setValue(ByteString.copyFromUtf8("+ěščřžýáíé")))
-//      .setDuration(GpbDuration.newBuilder().setSeconds(123).setNanos(456))
-//      .setTimestamp(GpbTimestamp.newBuilder().setSeconds(123).setNanos(456))
-//      .setListValue(ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(456.789)))
-//      .build()
-//
-//    val expected = CaseClassExtensionsScala(
-//      boolValue = true,
-//      int32Value = 123,
-//      longValue = 456,
-//      floatValue = Some(123.456f),
-//      doubleValue = None,
-//      stringValue = None,
-//      bytesValue = ByteString.copyFromUtf8("+ěščřžýáíé"),
-//      duration = Duration.ofSeconds(123, 456),
-//      timestamp = Instant.ofEpochSecond(123, 456),
-//      listValue = Seq(NumberValue(456.789))
-//    )
-//
-//    val Good(converted) = gpb.asCaseClass[CaseClassExtensionsScala]
-//
-//    assertResult(expected)(converted)
-//
-//    assertResult(Good(gpb))(converted.asGpb[ExtensionsMessage])
-//  }
-//
-//  test("any extension to GPB and back") {
-//    val innerMessage = MessageInsideAnyField.newBuilder().setFieldInt(42).setFieldString("ahoj").build()
-//
-//    val orig = ExtClass(Instant.ofEpochSecond(12345), AnyValue.of(innerMessage))
-//
-//    val expected = ExtensionsMessage.newBuilder().setTimestamp(GpbTimestamp.newBuilder().setSeconds(12345)).setAny(Any.pack(innerMessage)).build()
-//
-//    val Good(converted) = orig.asGpb[ExtensionsMessage]
-//
-//    assertResult(expected)(converted)
-//
-//    val actual = converted.asCaseClass[ExtClass]
-//
-//    assertResult(Good(orig))(actual)
-//    assertResult(Good(innerMessage))(actual.flatMap(_.any.asGpb[MessageInsideAnyField]))
-//  }
+  test("Case class to GPB") {
+    val map = Map("first" -> "1", "second" -> "2")
+    val map2 = Map("first" -> 1, "second" -> 2)
+
+    val caseClassB = CaseClassB(0.9, "text")
+
+    val caseClassD = Seq(CaseClassD(Seq(caseClassB, caseClassB, caseClassB), OneOfNamed2.FooInt(9)))
+    val caseClassF = CaseClassF(Seq(caseClassB, caseClassB, caseClassB), None)
+
+    val caseClass = CaseClassA("ahoj", 9, Some(13), ByteString.EMPTY, List("a"), caseClassB, caseClassB, caseClassF, Some(caseClassB), None, Seq(caseClassB, caseClassB, caseClassB), caseClassD, List("a", "b"), Vector(3, 6), List(), "1, 2", map, map2)
+
+    val gpbInternal = Data2.newBuilder()
+      .setFieldDouble(0.9)
+      .setFieldBlob(ByteString.copyFromUtf8("text"))
+      .build()
+
+    val dataRepeated = Seq(gpbInternal, gpbInternal, gpbInternal)
+
+    val expectedGpb = TestMessageV3.Data.newBuilder()
+      .setFieldString("ahoj")
+      .setFieldIntName(9)
+      .setFieldOption(13)
+      .setFieldBlob(ByteString.EMPTY)
+      .setFieldGpb(gpbInternal)
+      .setFieldGpb2(gpbInternal)
+      .setFieldGpb3(Data5.newBuilder().addAllFieldGpb(dataRepeated.asJava).build())
+      .setFieldGpbOption(gpbInternal)
+      .addAllFieldGpbRepeated(dataRepeated.asJava)
+      .addFieldGpb2RepeatedRecurse(Data3.newBuilder().addAllFieldGpb(dataRepeated.asJava).setFooInt(9).build())
+      .addAllFieldStrings(Seq("a", "b").asJava)
+      .addAllFieldStringsName(Seq("a").asJava)
+      .addAllFieldOptionIntegers(Seq(3, 6).map(int2Integer).asJava)
+      .addAllFieldMap(map.map { case (key, value) => TestMessageV3.MapMessage.newBuilder().setKey(key).setValue(value).build() }.asJava)
+      .addAllFieldMap2(map2.map { case (key, value) => TestMessageV3.MapMessage.newBuilder().setKey(key).setValue(value.toString).build() }.asJava)
+      .addAllFieldIntegers2(Seq(1, 2).map(int2Integer).asJava)
+      .build()
+
+    caseClass.asGpb[Data] match {
+      case Good(e) if e == expectedGpb => // ok
+    }
+  }
+
+  test("convert case class to GPB and back") {
+    val map = Map("first" -> "1", "second" -> "2")
+
+    val original = CaseClassC(StringWrapperClass("ahoj"), 9, Some(13), ByteString.EMPTY, Vector("a"), CaseClassB(0.9, "text"), Some(CaseClassB(0.9, "text")), None, Array("a", "b"), Vector(3, 6), List(), map)
+
+    val Good(converted) = original.asGpb[Data]
+
+    assertResult(Good(original))(converted.asCaseClass[CaseClassC])
+  }
+
+  test("convert case class with ignored field to GPB and back") {
+    val original = CaseClassE(fieldString = "ahoj", fieldOption = Some("ahoj2"))
+
+    val Good(converted) = original.asGpb[Data4]
+
+    assertResult(Good(original))(converted.asCaseClass[CaseClassE])
+  }
+
+  test("gpb3 map to GPB and back") {
+    val original = CaseClassG(fieldString = "ahoj",
+      fieldOption = Some("ahoj2"),
+      fieldMap = Map("one" -> 1, "two" -> 2),
+      fieldMap2 = Map("one" -> CaseClassMapInnerMessage("str", 42))
+    )
+
+    val Good(converted) = original.asGpb[Data4]
+
+    assertResult(Good(original))(converted.asCaseClass[CaseClassG])
+  }
+
+  test("extensions from GPB and back") {
+    val gpb = ExtensionsMessage.newBuilder()
+      .setBoolValue(BoolValue.newBuilder().setValue(true))
+      .setInt32Value(Int32Value.newBuilder().setValue(123))
+      .setInt64Value(Int64Value.newBuilder().setValue(456))
+      .setFloatValue(FloatValue.newBuilder().setValue(123.456f))
+      .setBytesValue(BytesValue.newBuilder().setValue(ByteString.copyFromUtf8("+ěščřžýáíé")))
+      .setDuration(GpbDuration.newBuilder().setSeconds(123).setNanos(456))
+      .setTimestamp(GpbTimestamp.newBuilder().setSeconds(123).setNanos(456))
+      .setListValue(ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(456.789)))
+      .setListValue2(ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(456.789)))
+      .setListValue3(ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(456.789)))
+      .setStruct(Struct.newBuilder().putFields("mapKey", Value.newBuilder().setNumberValue(42).build()))
+      .build()
+
+    val expected = CaseClassExtensions(
+      boolValue = BoolValue.newBuilder().setValue(true).build(),
+      int32Value = Int32Value.newBuilder().setValue(123).build(),
+      longValue = Int64Value.newBuilder().setValue(456).build(),
+      floatValue = Some(FloatValue.newBuilder().setValue(123.456f).build()),
+      doubleValue = None,
+      stringValue = None,
+      bytesValue = BytesValue.newBuilder().setValue(ByteString.copyFromUtf8("+ěščřžýáíé")).build(),
+      duration = GpbDuration.newBuilder().setSeconds(123).setNanos(456).build(),
+      timestamp = GpbTimestamp.newBuilder().setSeconds(123).setNanos(456).build(),
+      listValue = ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(456.789)).build(),
+      listValue2 = Seq(NumberValue(456.789)),
+      listValue3 = Some(Seq(NumberValue(456.789))),
+      listValue4 = None,
+      struct = Map("mapKey" -> NumberValue(42))
+    )
+
+    val Good(converted) = gpb.asCaseClass[CaseClassExtensions]
+
+    assertResult(expected)(converted)
+
+    assertResult(Good(gpb))(converted.asGpb[ExtensionsMessage])
+  }
+
+  test("extensions from GPB and back - scala types") {
+    val gpb = ExtensionsMessage.newBuilder()
+      .setBoolValue(BoolValue.newBuilder().setValue(true))
+      .setInt32Value(Int32Value.newBuilder().setValue(123))
+      .setInt64Value(Int64Value.newBuilder().setValue(456))
+      .setFloatValue(FloatValue.newBuilder().setValue(123.456f))
+      .setBytesValue(BytesValue.newBuilder().setValue(ByteString.copyFromUtf8("+ěščřžýáíé")))
+      .setDuration(GpbDuration.newBuilder().setSeconds(123).setNanos(456))
+      .setTimestamp(GpbTimestamp.newBuilder().setSeconds(123).setNanos(456))
+      .setListValue(ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(456.789)))
+      .build()
+
+    val expected = CaseClassExtensionsScala(
+      boolValue = true,
+      int32Value = 123,
+      longValue = 456,
+      floatValue = Some(123.456f),
+      doubleValue = None,
+      stringValue = None,
+      bytesValue = ByteString.copyFromUtf8("+ěščřžýáíé"),
+      duration = Duration.ofSeconds(123, 456),
+      timestamp = Instant.ofEpochSecond(123, 456),
+      listValue = Seq(NumberValue(456.789))
+    )
+
+    val Good(converted) = gpb.asCaseClass[CaseClassExtensionsScala]
+
+    assertResult(expected)(converted)
+
+    assertResult(Good(gpb))(converted.asGpb[ExtensionsMessage])
+  }
+
+  test("any extension to GPB and back") {
+    val innerMessage = MessageInsideAnyField.newBuilder().setFieldInt(42).setFieldString("ahoj").build()
+
+    val orig = ExtClass(Instant.ofEpochSecond(12345), AnyValue.of(innerMessage))
+
+    val expected = ExtensionsMessage.newBuilder().setTimestamp(GpbTimestamp.newBuilder().setSeconds(12345)).setAny(Any.pack(innerMessage)).build()
+
+    val Good(converted) = orig.asGpb[ExtensionsMessage]
+
+    assertResult(expected)(converted)
+
+    val actual = converted.asCaseClass[ExtClass]
+
+    assertResult(Good(orig))(actual)
+    assertResult(Good(innerMessage))(actual.flatMap(_.any.asGpb[MessageInsideAnyField]))
+  }
 }
 
 case class CaseClassA(fieldString: String,


### PR DESCRIPTION
So far only variable name was visible from runtime `CactusFailure`, but without context. Now the whole variable path should be visible - checked in unit tests.  
Unfortunately to implement this it was necessary to implement also #30 - conversion from case class to GPB didn't use any kind of error handling. From now on, `Converter`s `apply` method returns `scalatic.Or` instead of plain type and whole conversion (in both ways) is done using _scalactic_ features and therefore it collects all errors.
Solves #21 and #30