### PR TITLE
fix: Set target Java bytecode to version 1.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ lazy val commonSettings = Seq(
   scalacOptions += "-deprecation",
   scalacOptions += "-unchecked",
   scalacOptions += "-feature",
+  scalacOptions += "-target:jvm-1.8",
   resolvers += Resolver.jcenterRepo,
 
   organization := "com.avast.cactus",


### PR DESCRIPTION
Travis was reconfigured to use JDK11 which caused the project to be compiled to Java 11 bytecode. We still need to use Java 8.